### PR TITLE
Make mpi4py (technically) optional.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -291,7 +291,7 @@ setup(
     # optional targets:
     #   docs requires 'docutils', 'sphinx>=1.4', 'sphinx_rtd_theme'
     #   build_gromacs requires 'cmake>=3.4'
-    install_requires=['setuptools>=28', 'scikit-build', 'cmake', 'mpi4py', 'networkx'],
+    install_requires=['setuptools>=28', 'scikit-build', 'cmake', 'networkx'],
 
     author='M. Eric Irrgang',
     author_email='ericirrgang@gmail.com',

--- a/src/gmx/context.py
+++ b/src/gmx/context.py
@@ -589,7 +589,10 @@ class ParallelArrayContext(object):
         a single pass.
         """
 
-        from mpi4py import MPI
+        try:
+            from mpi4py import MPI
+        except:
+            raise exceptions.OptionalFeatureNotAvailableError("ParallelArrayContext requires Python package mpi4py to function.")
 
         if self._session is not None:
             raise exceptions.Error('Already running.')


### PR DESCRIPTION
More needs to be done to make it truly optional, but at least now the
package can be built, installed, and loaded without mpi4py.