### PR TITLE
Readthedocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Build Status](https://travis-ci.org/kassonlab/gmxapi.svg?branch=dev_0_0_4)](https://travis-ci.org/kassonlab/gmxapi)
+[![Documentation Status](https://readthedocs.org/projects/gmxapi/badge/?version=readthedocs)](http://gmxapi.readthedocs.io/en/readthedocs/?badge=readthedocs)
 
 The gmxapi project provides interfaces for managing and extending molecular dynamics simulation workflows.
 In this repository, a Python package provides the `gmx` module for high-level interaction with GROMACS.
@@ -204,7 +205,7 @@ if you come up with any tips or tricks!
 Documentation for the Python classes and functions in the gmx module can be accessed in the usual ways, using `pydoc`
 from the command line or `help()` in an interactive Python session.
 
-Additional documentation can be browsed on readthedocs.org or built with Sphinx after installation.
+Additional documentation can be browsed on [readthedocs.org](http://gmxapi.readthedocs.io/en/readthedocs/) or built with Sphinx after installation.
 
 To build the user documentation locally, first make sure you have sphinx installed, such as by doing
 a `pip install sphinx` or by using whatever package management system you are familiar with.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,5 @@ py>=1.4.34
 pytest>=3.2.2
 setuptools>=28.0.0
 scikit-build>=0.6.1
-setuptools_scm>=1.15.6
 virtualenv>=15.1.0
 networkx>=2.0
-mpi4py>=3.0


### PR DESCRIPTION
With these changes, readthedocs.org should be able to build docs for us (though the builds occasionally time out and we'll have to work on that). References in the README.md point at a `readthedocs` branch of the gmxapi/gmxapi project branch, which is actually a fork of kassonlab/gmxapi. When we confirm that the docs are building, we can update the links in a separate PR.