### PR TITLE
Build faster on readthedocs.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -210,10 +210,19 @@ class CMakeGromacsBuild(build_ext):
         if build_gromacs:
             gromacs_url = "https://github.com/kassonlab/gromacs-gmxapi/archive/master.zip"
             gmxapi_DIR = os.path.join(extdir, 'data/gromacs')
-            extra_cmake_args = ['-DCMAKE_INSTALL_PREFIX=' + gmxapi_DIR,
-                                '-DGMX_FFT_LIBRARY=fftpack',
-                                '-DGMX_GPU=OFF',
-                                '-DGMX_THREAD_MPI=ON']
+            if build_for_readthedocs:
+                extra_cmake_args = ['-DCMAKE_INSTALL_PREFIX=' + gmxapi_DIR,
+                                    '-DGMX_FFT_LIBRARY=fftpack',
+                                    '-DGMX_GPU=OFF',
+                                    '-DGMX_OPENMP=OFF',
+                                    '-DGMX_SIMD=None',
+                                    '-DGMX_USE_RDTSCP=OFF',
+                                    '-DGMX_MPI=OFF']
+            else:
+                extra_cmake_args = ['-DCMAKE_INSTALL_PREFIX=' + gmxapi_DIR,
+                                    '-DGMX_BUILD_OWN_FFTW=ON',
+                                    '-DGMX_GPU=OFF',
+                                    '-DGMX_THREAD_MPI=ON']
 
             # Warning: make sure not to recursively build the Python module...
             get_gromacs(gromacs_url,


### PR DESCRIPTION
We only have 15 minutes to build on readthedocs.org, which is really pushing it for GROMACS. We really need to either mock up the library so Sphinx can run or fetch a binary artifact from Travis-CI. Until then, we can just try to build GROMACS as fast as possible.