### PR TITLE
Work around broken pip 10.0 until we can ditch pip.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,15 +42,21 @@ install:
   - pushd gromacs-gmxapi-master
   - mkdir build
   - pushd build
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME -DGMX_FFT_LIBRARY=fftpack -DGMX_GPU=OFF -DGMX_OPENMP=OFF -DGMX_SIMD=None -DGMX_USE_RDTSCP=OFF -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI ..
+  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/gromacs -DGMX_FFT_LIBRARY=fftpack -DGMX_GPU=OFF -DGMX_OPENMP=OFF -DGMX_SIMD=None -DGMX_USE_RDTSCP=OFF -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI ..
   - make -j4 install
   - popd
   - popd
-  - python -m pip install --upgrade pip --user
-  - pip install --upgrade setuptools --user
-  - pip install virtualenv pytest cmake numpy mpi4py networkx --user
+  # pip 10 appears to be broken
+  - python -m pip install --upgrade pip==9 --user
+  - python -m pip install --upgrade setuptools --user
+  - python -m pip install virtualenv --user
+  - python -m pip install pytest --user
+  - python -m pip install cmake --user
+  - python -m pip install numpy --user
+  - python -m pip install mpi4py --user
+  - python -m pip install networkx --user
 
 script:
-  - GROMACS_DIR=$HOME pip install . --verbose --user
+  - GROMACS_DIR=$HOME/gromacs python -m pip install . --verbose --user
   - mpiexec -n 2 python -m mpi4py -m pytest --log-cli-level=DEBUG --pyargs gmx -s --verbose 
 


### PR DESCRIPTION
In resolving dependencies for the line
`python -m pip install virtualenv pytest cmake numpy mpi4py networkx --user`
a command is produced calling
`/usr/bin/python -m pip install --ignore-installed --no-user` but
`--no-user` is not a valid pip option.

Clean up Travis-CI build a bit.