### PR TITLE
gmxapi-64 Unique work spec identification

### DIFF
--- a/src/gmx/exceptions.py
+++ b/src/gmx/exceptions.py
@@ -20,6 +20,7 @@ from __future__ import unicode_literals
 
 __all__ = ['Error',
            'ApiError',
+           'CompatibilityError',
            'FileError',
            'OptionalFeatureNotAvailableError',
            'OptionalFeatureNotAvailableWarning',
@@ -39,6 +40,9 @@ class UsageError(Error):
 
 class ApiError(Error):
     """An API operation was attempted with an incompatible object."""
+
+class CompatibilityError(Error):
+    """An operation or data is incompatible with the current gmxapi environment."""
 
 class FileError(Error):
     """Problem with a file or filename."""


### PR DESCRIPTION
Addresses issue #64 

* Add __hash__ and serialize() instance methods to WorkSpec.
* Add deserialize() class method to WorkSpec.
* Add uid() instance method to WorkSpec to generate a consistent, concise
  and sufficiently unique string to identify a gmxapi_workspec_0_1 dataset.
* Update WorkSpec documentation.
* Add a CompatibilityError exception.