### PR TITLE
Allow control of whether output is truncated or appended.

### DIFF
--- a/src/gmx/core/export_context.cpp
+++ b/src/gmx/core/export_context.cpp
@@ -92,6 +92,23 @@ void setMDArgs(std::vector<std::string>* mdargs, py::dict params)
         mdargs->emplace_back("-maxh");
         mdargs->emplace_back(val);
     }
+    if (params.contains("append_output"))
+    {
+        try
+        {
+            if (! params["append_output"].cast<bool>())
+            {
+                mdargs->emplace_back("-noappend");
+            }
+        }
+        catch (const py::cast_error& e)
+        {
+            // Couldn't cast to bool for some reason.
+            // Convert to gmxapi exception (not implemented)
+            // ref. https://github.com/kassonlab/gmxapi/issues/125
+            throw;
+        }
+    }
 }
 
 void export_context(py::module &m)

--- a/src/gmx/workflow.py
+++ b/src/gmx/workflow.py
@@ -557,6 +557,7 @@ def from_tpr(input=None, **kwargs):
         pme_threads_per_rank (int): Number of OpenMP threads per PME rank. (-ntomp_pme)
         steps (int): Override input files and run for this many steps. (-nsteps)
         max_hours (float): Terminate after 0.99 times this many hours if simulation is still running. (-maxh)
+        append_output (bool): Append output for continuous trajectories if True, truncate existing output data if False. (default True)
 
     Returns:
         simulation member of a gmx.workflow.WorkSpec object
@@ -612,6 +613,9 @@ def from_tpr(input=None, **kwargs):
             params['steps'] = int(kwargs[arg_key])
         elif arg_key == 'max_hours' or arg_key == 'maxh':
             params['max_hours'] = float(kwargs[arg_key])
+        elif arg_key == 'append_output':
+            # Try not to encourage confusion with the `mdrun` `-noappend` flag, which would be a confusing double negative if represented as a bool.
+            params['append_output'] = bool(kwargs[arg_key])
         else:
             raise exceptions.UsageError("Invalid key word argument: {}. {}".format(arg_key, usage))
 


### PR DESCRIPTION
Relates to issue #40

Functionally, add a boolean `append_output` property to MD simulations
that defaults to `true`. Implemented with an optional keyword / param
that, if set `false`, gives the `mdrun -noappend` behavior.

I'm not sure that I think this is the right way to go. At least not completely. I think it is an appropriate keyword argument for the Python helper function, but I think we should separate the concepts of simulation parameters and output parameters before muddying the water further. That said, it may be that we should merge this PR now and be comfortable that at least the helper function syntax won't have to change if we decide that the resulting workspec or implementation details may change. It would be nice to revisit this before specifying the next workspec schema.