### PR TITLE
Handle both Python 2 and Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,85 +1,298 @@
+# Recipe for build and integration testing on Travis-CI
+
+# Try beta version of new travis-yml checker
+version: "= 0"
+# For extra debugging of failed jobs, see
+# https://docs.travis-ci.com/user/common-build-problems/#Troubleshooting-Locally-in-a-Docker-Image
+
 language: cpp
 sudo: false
 
-# At some point, we will test specific combinations of options, but not all permutations, so we use explicit matrix.
+# Different compiler or env are supposed to trigger different caches, but I had a hard time diagnosing problems
+# in gromacs-gmxapi until I specified a separate ccache for each matrix build element.
+# Note the heuristics for whether cache is shared or distinct:
+# https://docs.travis-ci.com/user/caching/#Caches-and-build-matrices
+cache:
+  pip: true
+  apt: true
+  directories:
+    - $HOME/.ccache_gromacs
+# This should be in a separate cache already because of the different compiler
+#    - $HOME/.ccache_gromacs_mpi
+    - $HOME/.ccache_py27
+    - $HOME/.ccache_py33
+    - $HOME/install
+    - $HOME/py2venv
+    - $HOME/py2venv_devel
+    - $HOME/py3venv
+    - $HOME/py3venv_devel
+os: linux
+
+# When building for the master branch, we want to know if building against the devel branch of a collaborating
+# repository breaks, but we don't want it to cause the CI test to be considered "failed"
+#
+# Permutations to test (ultimately):
+# - build gmaxpi against gromacs-gmxapi master (if gmxapi devel fails against gromacs master, decide whether or not
+#   this is okay and then disable the build for that release tag)
+# - build against gromacs-gmxapi devel, unless gmxapi branch is master (because we presumably just did a tested merge)
+# - build with MPI GROMACS and with tMPI GROMACS
+# - build with Python 2.7 and Python 3.4 for sample_restraint devel branch, but don't fail on sample_restraint errors (use after_script).
+# - clang, gcc 4.9+,... , intel compiler
+#
+# A pruned list of explicit permutations:
+# - Py 2.7, gromacs devel, tMPI, sample_restraint devel, clang
+# - Py 3.4, gromacs devel, MPI, sample_restraint devel, gcc 4.8.5 (good enough for pybind?)
+#
+# We can also use build staging (and maybe cache installation directories?) to reduce the combinatorics.
+# Note: "Stages group jobs that run in parallel, while their stages run sequentially."
+# E.g. stage1: build and install gromacs release >= 0.0.6 with and without MPI (preferably with several compilers). Skip for Py3 env.
+#      stage2: build gromacs and install devel with and without MPI unless gmxapi branch is master.
+#      stage3a: build gmxapi with Python 2.7 and Python 3.4 for both with and without MPI against gromacs release >= 0.0.6
+#      stage3b: repeat 3a for gromacs devel unless gmxapi branch is master
+#      stage3c: build but don't install with mismatched compilers according to 'env' against devel unless gmxapi is master
+#      stage4: build sample_restraint devel for each stage3b output unless gmxapi branch is master
+# The idea is that there are fewest permutations at stage1, which is our most expensive stage.
+#
+# We should also test both static and dynamically linked builds...
+#
+# Reference https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle
+
 matrix:
 
   include:
 
-  - os: linux
-    compiler: gcc
+  # Build and install gromacs release
+#  - stage: GROMACS 0.0.6
+
+  # Build and install gromacs devel
+  - stage: GROMACS devel
+    compiler: gcc # MPI
+    env:
+      - MATRIX_EVAL="CI_MPI=1 && CC=`which mpicc` && CXX=`which mpic++`"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - ccache
+          - cmake
+          - cmake-data
+          - doxygen
+          - libblas-dev
+          - libcr-dev
+          - libfftw3-dev
+          - liblapack-dev
+          - libmpich-dev
+          - libxml2-dev
+          - mpich
+    before_script: true
+    script: true
+    after_script: true
+
+  - compiler: gcc # non-MPI, upgraded gcc
+    env:
+      - MATRIX_EVAL="CI_MPI=0 && CC=`which gcc-6` && CXX=`which g++-6`"
+    addons:
+      apt:
+        sources:
+          - ubuntu-toolchain-r-test
+        packages:
+          - ccache
+          - cmake
+          - cmake-data
+          - doxygen
+          - gcc-6
+          - g++-6
+          - libblas-dev
+          - libcr-dev
+          - libfftw3-dev
+          - liblapack-dev
+          - libmpich-dev
+          - libxml2-dev
+          - mpich
+    before_script: true
+    script: true
+    after_script: true
+
+  # Build and install gmxapi with Py2.7 and Py3.4 both with and without MPI
+  - stage: GMXAPI with GROMACS
+    compiler: gcc # tMPI, Py2.7
+    env:
+      - MATRIX_EVAL="CI_MPI=0 && CC=`which gcc-6` && CXX=`which g++-6`"
+    install: true
     addons:
       apt:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - doxygen
-        - python
-        - mpich
-        - libmpich-dev
-        - libxml2-dev
-        - libblas-dev
         - cmake
         - cmake-data
-        - liblapack-dev
-        - g++-6
+        - doxygen
         - gcc-6
-    env:
-      - GMX_MPI=OFF
-      - GMX_THREAD_MPI=ON
-      - gmxapi_DIR=$HOME/gromacs
-      - GROMACS_DIR=$HOME/gromacs
-      - GROMACS_TAG=devel
-# Todo: GROMACS_TAG=devel needs to be fixed before merging to a release branch.
-# What makes me uncomfortable is that this is not automatic, but maybe that is for the best. We should check the
-# version dependencies before issuing a release or merging to master. This is described in RELEASE.txt
+        - g++-6
+        - libblas-dev
+        - libcr-dev
+        - libfftw3-dev
+        - liblapack-dev
+        - libmpich-dev
+        - libxml2-dev
+        - mpich
+        - python
+    # Python environment set-up
+    before_script:
+      - python -m virtualenv $HOME/py2venv_devel
+      - source $HOME/py2venv_devel/bin/activate
+      - ls $HOME/install && ls $HOME/install/gromacs_devel && ls $HOME/install/gromacs_devel/bin
+      - source $HOME/install/gromacs_devel/bin/GMXRC
+      - export CCACHE_DIR=$HOME/.ccache_py27
+      - export PYTHON=`which python`
 
+  - compiler: gcc  # tMPI, Py3.4
+    env:
+      - MATRIX_EVAL="CI_MPI=0 && CC=`which gcc-6` && CXX=`which g++-6`"
+    install: true
+    # Python environment set-up
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - cmake
+        - cmake-data
+        - doxygen
+        - gcc-6
+        - g++-6
+        - libblas-dev
+        - libcr-dev
+        - libfftw3-dev
+        - liblapack-dev
+        - libmpich-dev
+        - libxml2-dev
+        - mpich
+        - python3
+        - python3.4-venv
+# package name changes in Ubuntu 15
+#        - python3-venv
+    before_script:
+      - python3 -m venv $HOME/py3venv_devel
+      - source $HOME/py3venv_devel/bin/activate
+      - ls $HOME/install && ls $HOME/install/gromacs_devel && ls $HOME/install/gromacs_devel/bin
+      - source $HOME/install/gromacs_devel/bin/GMXRC
+      - export CCACHE_DIR=$HOME/.ccache_py34
+      - export PYTHON=`which python`
+
+  - compiler: gcc # MPI, Py2.7
+    env:
+      - MATRIX_EVAL="CI_MPI=1 && CC=`which mpicc` && CXX=`which mpic++`"
+    install: true
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - cmake
+        - cmake-data
+        - doxygen
+        - libblas-dev
+        - libcr-dev
+        - libfftw3-dev
+        - liblapack-dev
+        - libmpich-dev
+        - libxml2-dev
+        - mpich
+        - python
+    # Python environment set-up
+    before_script:
+      - python -m virtualenv $HOME/py2venv_devel
+      - source $HOME/py2venv_devel/bin/activate
+      - ls $HOME/install && ls $HOME/install/gromacs_devel && ls $HOME/install/gromacs_devel/bin
+      - source $HOME/install/gromacs_devel/bin/GMXRC
+      - export CCACHE_DIR=$HOME/.ccache_py27
+      - export PYTHON=`which python`
+
+  - compiler: gcc # MPI, Py3.4
+    env:
+      - MATRIX_EVAL="CI_MPI=1 && CC=`which mpicc` && CXX=`which mpic++`"
+    install: true
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - cmake
+        - cmake-data
+        - doxygen
+        - libblas-dev
+        - libcr-dev
+        - libfftw3-dev
+        - liblapack-dev
+        - libmpich-dev
+        - libxml2-dev
+        - mpich
+        - python3
+        - python3.4-venv
+# package name changes in Ubuntu 15
+#        - python3-venv
+    # Python environment set-up
+    before_script:
+      - python3 -m venv $HOME/py3venv_devel
+      - source $HOME/py3venv_devel/bin/activate
+      - ls $HOME/install && ls $HOME/install/gromacs_devel && ls $HOME/install/gromacs_devel/bin
+      - source $HOME/install/gromacs_devel/bin/GMXRC
+      - export CCACHE_DIR=$HOME/.ccache_py34
+      - export PYTHON=`which python`
+
+
+# We also have access to tricks like [[ $TRAVIS_PULL_REQUEST == “false” ]] && [[ $TRAVIS_BRANCH == “master” ]]
+# but note that TRAVIS_BRANCH is the target branch and not the source branch for a pull request.
+# See also https://docs.travis-ci.com/user/environment-variables/#Default-Environment-Variables
+
+# Set up for all jobs
 before_install:
   - uname -a
   - apt list --installed
-  - test -n $CC  && unset CC
-  - test -n $CXX && unset CXX
-  - wget https://github.com/kassonlab/gromacs-gmxapi/archive/$GROMACS_TAG.zip
-  - unzip $GROMACS_TAG.zip
+  - dpkg-query -L doxygen
+  - eval "${MATRIX_EVAL}"
+  - export CCACHE_COMPILERCHECK=content
+  - export CCACHE_SLOPPINESS="file_macro,include_file_ctime,include_file_mtime,no_system_headers,pch_defines,time_macros"
+  - ${CC} --version
+  - ${CXX} --version
 
+# Skip install step by setting `install: true` when skipping gromacs build stages
 install:
-  - pushd gromacs-gmxapi-$GROMACS_TAG
-  - mkdir build
-  - pushd build
-  - cmake -DCMAKE_INSTALL_PREFIX=$HOME/gromacs -DGMX_FFT_LIBRARY=fftpack -DGMX_GPU=OFF -DGMX_OPENMP=OFF -DGMX_SIMD=None -DGMX_USE_RDTSCP=OFF -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI ..
-  - make -j4 install
+  - export CCACHE_DIR=$HOME/.ccache_gromacs
+  - ccache -s
+  - git clone --depth=1 --no-single-branch https://github.com/kassonlab/gromacs-gmxapi.git
+  - pushd gromacs-gmxapi
+  - git branch -a
+  # \todo add 0.0.6 build
+  - git checkout devel
+  - pwd
+  - mkdir build && pushd build && cmake -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DBUILD_TESTING=ON -DGMX_DOUBLE=$GMX_DOUBLE -DGMX_MPI=$GMX_MPI -DGMX_THREAD_MPI=$GMX_THREAD_MPI -DCMAKE_INSTALL_PREFIX=$HOME/install/gromacs_devel .. && make -j1 install
   - popd
-  - popd
-  - python -m pip install --upgrade pip --user
-  - python -m pip install --upgrade setuptools --user
-  - python -m pip install virtualenv --user
-  - python -m pip install pytest --user
-  - python -m pip install numpy --user
-  - python -m pip install mpi4py --user
-  - python -m pip install networkx --user
-  - python -m pip install sphinx --user
-  - python -m pip install sphinx_rtd_theme --user
+  - ccache -s
 
+
+# Python build steps
 script:
+  - ccache -s
+  - $PYTHON -m pip install --upgrade pip
+  - $PYTHON -m pip install --upgrade setuptools
+  - $PYTHON -m pip install virtualenv
+  - $PYTHON -m pip install pytest numpy mpi4py networkx sphinx sphinx_rtd_theme
   - mkdir build
   - pushd build
-  # install in user site-packages directory
-  - GROMACS_DIR=$HOME/gromacs cmake .. -DPYTHON_EXECUTABLE=`which python` -DGMXAPI_USER_INSTALL=ON
+  - cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DPYTHON_EXECUTABLE=$PYTHON
   - make -j4 install
   - make -j4 docs
   - popd
-  - mpiexec -n 2 python -m mpi4py -m pytest --log-cli-level=DEBUG --pyargs gmx -s --verbose
-  - pip uninstall -y gmx
-  # install in virtualenv
-  - virtualenv venv
-  - source venv/bin/activate
-  - pip install numpy mpi4py networkx pytest
-  - pushd build
-  # Do an intentionally non-thorough job of removing previous build: test unclean build directory.
-  - rm CMakeCache.txt
-  - GROMACS_DIR=$HOME/gromacs cmake .. -DPYTHON_EXECUTABLE=`which python`
-  - make -j4 install
-  - popd
-  - mpiexec -n 2 python -m mpi4py -m pytest --log-cli-level=DEBUG --pyargs gmx -s --verbose
+  - mpiexec -n 2 $PYTHON -m mpi4py -m pytest --log-cli-level=DEBUG --pyargs gmx -s --verbose
+  - ccache -s
 
+# We can use this step to remove something we don't want cached, like the gmx Python package in the site-packages
+# directory, though right now our clumsy cmake should just replace it without question.
+before_cache: true
+
+# Sample restraint
+after_script: true
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,8 @@ cmake_minimum_required(VERSION 3.4.3)
 # Sets the PROJECT_VERSION variable, as well...
 project(gmxpy VERSION 0.0.6)
 
+include(Ccache.cmake)
+
 # If the user is not in a virtual environment and is not a privileged user and has not specified an install location
 # for the Python module (GMXAPI_INSTALL_PATH), this option causes the automatic install location to query the user
 # site-packages directory instead of using the default site-packages directory for the interpreter.

--- a/Ccache.cmake
+++ b/Ccache.cmake
@@ -1,0 +1,49 @@
+# Reference https://crascit.com/2016/04/09/using-ccache-with-cmake/
+#
+# Here we try to make sure that ccache is invoked as `/.../ccache compiler args` to best handle more than one local
+# compiler or a compiler wrapper, whereas it is otherwise common to replace the default compilers with symbolic links
+# to the ccache binary.
+#
+# ccache only works for gcc compatible compilers. We should test with anything other than CMAKE_<LANG>_COMPILER_ID==GNU
+# Clang is reported to work with some caveats. See https://pspdfkit.com/blog/2015/ccache-for-fun-and-profit/
+# AppleClang
+# Clang
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+    # Set up wrapper scripts
+    if (CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "AppleClang" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+        message(STATUS "Setting up ccache wrapper for ${CMAKE_C_COMPILER_ID} C compiler ${CMAKE_C_COMPILER}")
+        set(C_LAUNCHER "${CCACHE_PROGRAM}")
+        configure_file(launch-c.in ${CMAKE_BINARY_DIR}/launch-c)
+        execute_process(COMMAND chmod a+rx "${CMAKE_BINARY_DIR}/launch-c")
+        if(CMAKE_GENERATOR STREQUAL "Xcode")
+            # Set Xcode project attributes to route compilation and linking
+            # through our scripts
+            set(CMAKE_XCODE_ATTRIBUTE_CC "${CMAKE_BINARY_DIR}/launch-c")
+            set(CMAKE_XCODE_ATTRIBUTE_LD "${CMAKE_BINARY_DIR}/launch-c")
+        else()
+            # Support Unix Makefiles and Ninja
+            set(CMAKE_C_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-c")
+        endif()
+    else()
+        message(STATUS "Skipping ccache set up. Not confirmed to work with compiler ID ${CMAKE_C_COMPILER_ID}.")
+    endif() # GNU C compiler
+    if (CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "AppleClang" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        message(STATUS "Setting up ccache wrapper for ${CMAKE_CXX_COMPILER_ID} CXX compiler ${CMAKE_CXX_COMPILER}")
+        set(CXX_LAUNCHER "${CCACHE_PROGRAM}")
+        configure_file(launch-cxx.in ${CMAKE_BINARY_DIR}/launch-cxx)
+        execute_process(COMMAND chmod a+rx "${CMAKE_BINARY_DIR}/launch-cxx")
+
+        if(CMAKE_GENERATOR STREQUAL "Xcode")
+            # Set Xcode project attributes to route compilation and linking
+            # through our scripts
+            set(CMAKE_XCODE_ATTRIBUTE_CXX        "${CMAKE_BINARY_DIR}/launch-cxx")
+            set(CMAKE_XCODE_ATTRIBUTE_LDPLUSPLUS "${CMAKE_BINARY_DIR}/launch-cxx")
+        else()
+            # Support Unix Makefiles and Ninja
+            set(CMAKE_CXX_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-cxx")
+        endif()
+    else()
+        message(STATUS "Skipping ccache set up. Not confirmed to work with compiler ID ${CMAKE_CXX_COMPILER_ID}.")
+    endif() # GNU C++ compiler
+endif() # ccache program

--- a/launch-c.in
+++ b/launch-c.in
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Set up compiler wrapper to make it easier to use ccache.
+#
+# Xcode generator doesn't include the compiler as the
+# first argument, Ninja and Makefiles do. Handle both cases.
+if [[ "$1" = "${CMAKE_C_COMPILER}" ]] ; then
+shift
+fi
+
+export CCACHE_CPP2=true
+exec "${C_LAUNCHER}" "${CMAKE_C_COMPILER}" "$@"

--- a/launch-cxx.in
+++ b/launch-cxx.in
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Set up compiler wrapper to make it easier to use ccache.
+#
+# Xcode generator doesn't include the compiler as the
+# first argument, Ninja and Makefiles do. Handle both cases.
+if [[ "$1" = "${CMAKE_CXX_COMPILER}" ]] ; then
+shift
+fi
+
+export CCACHE_CPP2=true
+exec "${CXX_LAUNCHER}" "${CMAKE_CXX_COMPILER}" "$@"

--- a/src/gmx/context.py
+++ b/src/gmx/context.py
@@ -548,7 +548,7 @@ class ParallelArrayContext(object):
                 def launch(rank=None):
                     assert not rank is None
                     tpr_file = infile[rank]
-                    logger.info('Loading TPR file: {}'.format(infile))
+                    logger.info('Loading TPR file: {}'.format(tpr_file))
                     system = gmx.core.from_tpr(tpr_file)
                     dag.nodes[name]['system'] = system
                     for potential in potential_list:

--- a/src/gmx/test/test_mpiarraycontext.py
+++ b/src/gmx/test/test_mpiarraycontext.py
@@ -138,12 +138,12 @@ class ConsumerBuilder(object):
 @pytest.mark.usefixtures("cleandir")
 class ArrayContextTestCase(unittest.TestCase):
     def test_basic(self):
-        md = gmx.workflow.from_tpr(tpr_filename)
+        md = gmx.workflow.from_tpr(tpr_filename, threads_per_rank=1)
         context = gmx.context.ParallelArrayContext(md)
         with context as session:
             session.run()
 
-        md = gmx.workflow.from_tpr([tpr_filename, tpr_filename])
+        md = gmx.workflow.from_tpr([tpr_filename, tpr_filename], threads_per_rank=1)
         context = gmx.context.ParallelArrayContext(md)
         with context as session:
             session.run()

--- a/src/gmx/test/test_pymd.py
+++ b/src/gmx/test/test_pymd.py
@@ -61,8 +61,12 @@ class BindingsTestCase(unittest.TestCase):
     def test_APIObjectsFromTpr(self):
         apisystem = gmx.core.from_tpr(tpr_filename)
         assert isinstance(apisystem, gmx.core.MDSystem)
+        context = gmx.core.Context()
+        mdargs = gmx.core.MDArgs()
+        mdargs.set({'threads_per_rank': 1})
+        context.setMDArgs(mdargs)
         assert hasattr(apisystem, 'launch')
-        session = apisystem.launch()
+        session = apisystem.launch(context)
         assert hasattr(session, 'run')
         session.run()
         # Test rerunability
@@ -100,14 +104,14 @@ class BindingsTestCase(unittest.TestCase):
 def test_simpleSimulation(caplog):
     """Load a work specification with a single TPR file and run."""
     # use case 1: simple high-level
-    md = gmx.workflow.from_tpr(tpr_filename)
+    md = gmx.workflow.from_tpr(tpr_filename, threads_per_rank=1)
     gmx.run(md)
 
 @pytest.mark.usefixtures("cleandir")
 @pytest.mark.usefixtures("caplog")
 @withmpi_only
 def test_array_context(caplog):
-    md = gmx.workflow.from_tpr(tpr_filename)
+    md = gmx.workflow.from_tpr(tpr_filename, threads_per_rank=1)
     context = gmx.context.ParallelArrayContext(md)
     with context as session:
         session.run()
@@ -117,7 +121,7 @@ def test_array_context(caplog):
 @withmpi_only
 def test_plugin(caplog):
     # Test attachment of external code
-    md = gmx.workflow.from_tpr(tpr_filename)
+    md = gmx.workflow.from_tpr(tpr_filename, threads_per_rank=1)
 
     # Create a WorkElement for the potential
     #potential = gmx.core.TestModule()

--- a/src/gmx/test/test_workflow.py
+++ b/src/gmx/test/test_workflow.py
@@ -6,6 +6,9 @@ import pytest
 import gmx
 import json
 import os
+from gmx.util import to_string
+from gmx.util import to_utf8
+
 # # Get a test tpr filename
 # from gmx.data import tpr_filename
 
@@ -62,13 +65,13 @@ class WorkElementTestCase(unittest.TestCase):
         params = {'input': ["filename1", "filename2"]}
         element = gmx.workflow.WorkElement(namespace=namespace, operation=operation, params=params)
 
-        json_data = element.serialize()
-        assert "namespace" in json.loads(json_data)
+        serialization = element.serialize()
+        assert "namespace" in json.loads(to_string(serialization))
 
         # Two elements with the same name cannot exist in the same workspec, but this is not the case here.
-        element = gmx.workflow.WorkElement.deserialize(json_data)
+        element = gmx.workflow.WorkElement.deserialize(serialization)
         assert element.name == None
-        element = gmx.workflow.WorkElement.deserialize(json_data, name=name)
+        element = gmx.workflow.WorkElement.deserialize(serialization, name=name)
         assert element.name == name
 
         assert element.workspec == workspec
@@ -182,7 +185,7 @@ class WorkflowFreeFunctions(unittest.TestCase):
     """Test helpers and other free functions in gmx.workflow submodule."""
     def setUp(self):
         # check that we actually got an empty directory form "cleandir"
-        assert os.listdir(os.getcwd()) == []
+        assert len(os.listdir(os.getcwd())) == 0
         # Make sure that we have some "input files".
         # Expectations for sanity-checking input are open to discussion...
         with open(file1, 'wb'):

--- a/src/gmx/util.py
+++ b/src/gmx/util.py
@@ -6,6 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import sys
 import os
 
 __all__ = []
@@ -45,6 +46,71 @@ def _filetype(filename):
         return fileio.TprFile
     else:
         raise UsageError("Argument is not a readable file.")
+
+def to_utf8(input):
+    """Return a utf8 encoded byte sequence of the Unicode ``input`` or its string representation.
+
+    In Python 2, returns a :py:str object. In Python 3, returns a :py:bytes object.
+    """
+    py_version = sys.version_info.major
+    if py_version == 3:
+        if isinstance(input, str):
+            value = input.encode('utf-8')
+        elif isinstance(input, bytes):
+            value = input
+        else:
+            try:
+                string = str(input)
+            except:
+                raise UsageError("Cannot find a Python 3 string representation of input.")
+            value = string.encode('utf-8')
+    else:
+        assert py_version == 2
+        if isinstance(input, unicode):
+            value = input.encode('utf-8')
+        else:
+            try:
+                value = str(input)
+            except:
+                raise UsageError("Cannot find a Python 2 string representation of input.")
+    return value
+
+def to_string(input):
+    """Return a Unicode string representation of ``input``.
+
+    If ``input`` or its string representation is not already a Unicode object, attempt to decode as utf-8.
+
+    In Python 3, returns a native string, decoding utf-8 encoded byte sequences if necessary.
+
+    In Python 2, returns a Unicode object, converting data types if necessary and possible.
+
+    Note:
+        In Python 2, byte sequence objects are :py:str type, so passing a :py:str actually converts from :py:str: to
+        :py:unicode. To guarantee a native string object, wrap the output of this function in ``str()``.
+    """
+    py_version = sys.version_info.major
+    if py_version == 3:
+        if isinstance(input, str):
+            value = input
+        else:
+            try:
+                value = input.decode('utf-8')
+            except:
+                try:
+                    value = str(input)
+                except:
+                    raise UsageError("Cannot find a Python 3 string representation of input.")
+    else:
+        assert py_version == 2
+        if isinstance(input, unicode):
+            value = input
+        else:
+            try:
+                string = str(input)
+            except:
+                raise UsageError("Cannot find a Python 2 string representation of input.")
+            value = string.decode('utf-8')
+    return value
 
 def _test():
         import doctest


### PR DESCRIPTION
Test Python 2 and Python 3. Use a CI build matrix with aggressive caching.

Addresses #103 by letting us test various permutations in a reasonable amount of rebuild time. Note, if cache is not available for a given configuration, the first build will take a while. As this commit makes its way up to devel and then master, future pull requests will have access to better starting cache.

The first commit successfully identifies bug #104 so I will add another commit to the PR to fix that and #119 .