### PR TITLE
gmxapi-158 Add "end_time" keyword argument for gmx.workflow.from_tpr

### DIFF
--- a/src/gmx/core/CMakeLists.txt
+++ b/src/gmx/core/CMakeLists.txt
@@ -24,6 +24,8 @@ pybind11_add_module(pygmx_core
                     pymdmodule.cpp
                     pysystem.h
                     pysystem.cpp
+                    tprfile.cpp
+                    tprfile.h
                     )
 
 # The target name is for clarity, but the installed module will be gmx.core

--- a/src/gmx/core/core.cpp
+++ b/src/gmx/core/core.cpp
@@ -8,6 +8,7 @@
 #include <memory>
 
 #include "gmxpy_api.h"
+#include "tprfile.h"
 #include "gmxapi/status.h"
 
 #include "pybind11/pybind11.h"
@@ -77,4 +78,11 @@ PYBIND11_MODULE(core, m) {
     export_md(m);
     export_context(m);
     export_system(m);
+
+    m.def("copy_tprfile",
+            &gmxpy::copy_tprfile,
+            py::arg("source"),
+            py::arg("destination"),
+            py::arg("end_time"),
+            "Copy a TPR file from `source` to `destination`, replacing `nsteps` with `end_time`.");
 }

--- a/src/gmx/core/tprfile.cpp
+++ b/src/gmx/core/tprfile.cpp
@@ -1,0 +1,65 @@
+//
+// Created by Eric Irrgang on 8/14/18.
+//
+
+#include "tprfile.h"
+
+#include "gromacs/mdtypes/inputrec.h"
+#include "gromacs/topology/topology.h"
+#include "gromacs/mdtypes/state.h"
+#include "gromacs/fileio/oenv.h"
+#include "gromacs/fileio/tpxio.h"
+#include "gromacs/fileio/trxio.h"
+#include "gromacs/options/timeunitmanager.h"
+#include "gromacs/utility/cstringutil.h"
+#include "gromacs/utility/programcontext.h"
+
+
+bool gmxpy::copy_tprfile(std::string infile, std::string outfile, double until_t) {
+    bool success = false;
+
+    const char * top_fn = infile.c_str();
+    fprintf(stderr, "Reading toplogy and stuff from %s\n", top_fn);
+
+    t_inputrec  irInstance;
+    t_inputrec *ir = &irInstance;
+    gmx_mtop_t        mtop;
+    t_state           state;
+    read_tpx_state(top_fn, ir, &state, &mtop);
+
+
+    char              buf[200], buf2[200];
+
+
+
+    /* set program name, command line, and default values for output options */
+    gmx_output_env_t *oenv;
+    gmx::TimeUnit  timeUnit = gmx::TimeUnit_Default;
+    bool bView{false}; // argument that says we don't want to view graphs.
+    int xvgFormat{0};
+    output_env_init(&oenv, gmx::getProgramContext(),
+                    static_cast<time_unit_t>(timeUnit + 1), bView, // NOLINT(misc-misplaced-widening-cast)
+                    static_cast<xvg_format_t>(xvgFormat + 1), 0);
+
+    int64_t run_step = ir->init_step;
+    double run_t    = ir->init_step*ir->delta_t + ir->init_t;
+
+    // \todo log
+    printf("nsteps = %s, run_step = %s, current_t = %g, until = %g\n",
+           gmx_step_str(ir->nsteps, buf),
+           gmx_step_str(run_step, buf2),
+           run_t, until_t);
+
+    ir->nsteps = static_cast<int64_t>((until_t - run_t)/ir->delta_t + 0.5);
+
+    // \todo log
+    printf("Extending remaining runtime until %g ps (now %s steps)\n",
+           until_t, gmx_step_str(ir->nsteps, buf));
+
+    ir->init_step = run_step;
+
+    write_tpx_state(outfile.c_str(), ir, &state, &mtop);
+
+    success = true;
+    return success;
+}

--- a/src/gmx/core/tprfile.h
+++ b/src/gmx/core/tprfile.h
@@ -1,0 +1,27 @@
+//
+// Created by Eric Irrgang on 8/13/18.
+//
+
+#ifndef GMXPY_TPRFILE_H
+#define GMXPY_TPRFILE_H
+
+#include <string>
+
+namespace gmxpy
+{
+
+/*!
+ * \brief Copy and possibly update TPR file by name.
+ *
+ * \param infile Input file name
+ * \param outfile Output file name
+ * \param end_time Replace `nsteps` in infile with `end_time/dt`
+ * \return true if successful, else false
+ */
+bool copy_tprfile(std::string infile, std::string outfile, double end_time);
+
+
+
+}
+
+#endif //GMXPY_TPRFILE_H

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -1,8 +1,9 @@
 """Test gmx.fileio submodule"""
-
-import unittest
 import os
+import tempfile
+import unittest
 
+import gmx.core
 from gmx.fileio import TprFile
 from gmx.exceptions import UsageError
 
@@ -15,6 +16,13 @@ class TprTestCase(unittest.TestCase):
         # TprFile does not yet check whether file exists and is readable...
         #self.assertRaises(UsageError, TprFile, 1, 'r')
         fh = TprFile(tpr_filename, 'r')
+
+    def test_tprcopy(self):
+        _, temp_filename = tempfile.mkstemp(suffix='.tpr')
+        # When we have some more inspection tools we can do more than just check for success.
+        assert gmx.core.copy_tprfile(source=tpr_filename, destination=temp_filename, end_time=1.0)
+        os.unlink(temp_filename)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/gmx/test/test_pymd.py
+++ b/src/gmx/test/test_pymd.py
@@ -111,6 +111,13 @@ def test_simpleSimulation(caplog):
     gmx.run(md)
 
 @pytest.mark.usefixtures("cleandir")
+def test_modifiedInput(caplog):
+    """Load a work specification with a single TPR file and updated params."""
+    md = gmx.workflow.from_tpr(tpr_filename, threads_per_rank=1, end_time='0.02')
+    with gmx.context.ParallelArrayContext(md) as session:
+        session.run()
+
+@pytest.mark.usefixtures("cleandir")
 @pytest.mark.usefixtures("caplog")
 @withmpi_only
 def test_array_context(caplog):

--- a/src/gmx/workflow.py
+++ b/src/gmx/workflow.py
@@ -579,25 +579,35 @@ def from_tpr(input=None, **kwargs):
 
     If the MD operation discovers artifacts from a previous simulation that was launched from the same input,
     the simulation resumes from the last checkpointed step. If ``append_output`` is set ``False``, existing
-    artifacts are discarded, and new output begins from the last checkpointed step, if any.
+    artifacts are kept separate from new output with the standard file naming convention,
+    and new output begins from the last checkpointed step, if any.
+
+    Setting ``end_time`` redefines the end point of the simulation trajectory from what was provided in
+    ``input``. It is equivalent to changing the number of steps requested in the MDP (or TPR) input, but
+    it time is provided as picoseconds instead of a number of time steps.
 
     The stop condition for the MD operation may be overridden. If ``steps=N`` is provided and N is an integer
     greater than or equal to 1, the MD operation advances the trajectory by ``N`` steps, regardless of the number
-    of simulation steps specified in ``input``. For convenience, setting ``steps=None`` does not override ``input``.
+    of simulation steps specified in ``input`` or ``end_time``. For convenience, setting ``steps=None`` does not override
+    ``input``.
+    Note that when it is not ``None``, ``steps`` takes precedence over ``end_time`` and ``input``, but can still be
+    superceded by a signal, such as if an MD plugin or other code has a simulation completion condition that occurs
+    before ``N`` additional steps have run.
 
     Where key word arguments correspond to ``gmx mdrun`` command line options, the corresponding flags are noted below.
 
     Arguments:
         input (str): *Required* string or list of strings giving the filename(s) of simulation input
+        append_output (bool): Append output for continuous trajectories if True, truncate existing output data if False. (default True)
+        end_time (float): Specify the final time in the simulation trajectory, overriding input read from TPR.
         grid (tuple): Domain decomposition grid divisions (nx, ny, nz). (-dd)
+        max_hours (float): Terminate after 0.99 times this many hours if simulation is still running. (-maxh)
         pme_ranks (int): number of separate ranks to be used for PME electrostatics. (-npme)
-        threads (int): Total number of threads to start. (-nt)
-        tmpi (int): number of thread-MPI ranks to start. (-ntmpi)
-        threads_per_rank (int): number of OpenMP threads to start per MPI rank. (-ntomp)
         pme_threads_per_rank (int): Number of OpenMP threads per PME rank. (-ntomp_pme)
         steps (int): Override input files and run for this many steps. (-nsteps)
-        max_hours (float): Terminate after 0.99 times this many hours if simulation is still running. (-maxh)
-        append_output (bool): Append output for continuous trajectories if True, truncate existing output data if False. (default True)
+        threads (int): Total number of threads to start. (-nt)
+        threads_per_rank (int): number of OpenMP threads to start per MPI rank. (-ntomp)
+        tmpi (int): number of thread-MPI ranks to start. (-ntmpi)
 
     Returns:
         simulation member of a gmx.workflow.WorkSpec object
@@ -677,9 +687,10 @@ def from_tpr(input=None, **kwargs):
         elif arg_key == 'append_output':
             # Try not to encourage confusion with the `mdrun` `-noappend` flag, which would be a confusing double negative if represented as a bool.
             params['append_output'] = bool(kwargs[arg_key])
+        elif arg_key == 'end_time':
+            params[arg_key] = float(kwargs[arg_key])
         else:
             raise exceptions.UsageError("Invalid key word argument: {}. {}".format(arg_key, usage))
-
 
     # Create an empty WorkSpec
     workspec = WorkSpec()


### PR DESCRIPTION
Update for 0.0.6 release. Add "end_time" keyword argument to from_tpr()
function and clarify behavior of `end_time` and `steps`. For 0.0.6,
`end_time` is processed by the `load_tpr` operation in `gmx.context`.
The TPR file specified as the input source for the operation is copied
and updated by the framework in a temporary area as an implementation
detail. The original TPR file is left untouched.

For the more rigorous solution in 0.0.7, refer to issue #158.

This commit corresponds to a commit submitted against the release-0_0_6
branch and should not be applied until 0.0.6.1 is finalized in release-0_0_6.