### PR TITLE
TPR interaction tools

### DIFF
--- a/src/gmx/core/CMakeLists.txt
+++ b/src/gmx/core/CMakeLists.txt
@@ -19,8 +19,13 @@ pybind11_add_module(pygmx_core
                     core.cpp
                     export_context.cpp
                     export_md.cpp
+                    export_mdcheckpoint.cpp
+                    export_microstate.cpp
                     export_system.cpp
+                    export_tprfile.cpp
                     gmxpy_api.h
+                    mdcheckpoint.cpp
+                    microstate.cpp
                     pymdmodule.h
                     pymdmodule.cpp
                     pysystem.h

--- a/src/gmx/core/core.cpp
+++ b/src/gmx/core/core.cpp
@@ -76,8 +76,14 @@ PYBIND11_MODULE(core, m) {
 
 
     // Get bindings exported by the various components.
-    export_md(m);
+    // In the current implementation, sequence may be important. Exports that
+    // reference bindings from other exports should not be called before the
+    // dependencies are exported.
     export_context(m);
+    export_tprfile(m);
+    export_mdcheckpoint(m);
+    export_microstate(m);
+    export_md(m);
     export_system(m);
 
     m.def("copy_tprfile",

--- a/src/gmx/core/core.h
+++ b/src/gmx/core/core.h
@@ -41,6 +41,12 @@ void export_session(pybind11::module &m);
 
 void export_system(pybind11::module &m);
 
+void export_tprfile(pybind11::module &m);
+
+void export_mdcheckpoint(pybind11::module &m);
+
+void export_microstate(pybind11::module &m);
+
 } // end namespace gmxpy::detail
 
 }      // end namespace gmxpy

--- a/src/gmx/core/export_mdcheckpoint.cpp
+++ b/src/gmx/core/export_mdcheckpoint.cpp
@@ -1,0 +1,15 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#include "core.h"
+#include "mdcheckpoint.h"
+
+void gmxpy::detail::export_mdcheckpoint(pybind11::module &m) {
+    namespace py = pybind11;
+
+    // C++ may need to hold onto a MDCheckpoint for longer than a single Python
+    // function call, so we should use a reference-counted handle.
+    py::class_<MDCheckpoint, std::shared_ptr<MDCheckpoint>>
+    mdcheckpoint(m, "MDCheckpoint", "Handle to a simulation checkpoint.");
+}

--- a/src/gmx/core/export_microstate.cpp
+++ b/src/gmx/core/export_microstate.cpp
@@ -1,0 +1,29 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#include "core.h"
+#include "microstate.h"
+
+// TprFile and MDCheckpoint must be exported to Python before this export function
+// is called to ensure proper binding. In the future, we could handle this
+// assurance more robustly by querying the registered Context type for named
+// features or otherwise passing something around to each of the export functions,
+// but such checks would happen at the time of Python module import. I can't
+// think of a way to generate a compile-time error if, say, gmxpy::TprFile is
+// referenced before export_tprfile will have had a chance to register the class
+// and holder type.
+void gmxpy::detail::export_microstate(pybind11::module &m) {
+    namespace py = pybind11;
+
+    py::class_<Microstate> microstate(m, "Microstate", "Simulation microstate");
+
+    // Get ownership of a microstate proxy object.
+    m.def("get_microstate",
+        [](const TprFile& tprFile, const MDCheckpoint& checkpoint) -> std::unique_ptr<Microstate>
+        {
+            return readMicrostate(tprFile, checkpoint);
+        },
+          "Get a handle to the simulation microstate associated with the provided inputs.");
+
+}

--- a/src/gmx/core/export_tprfile.cpp
+++ b/src/gmx/core/export_tprfile.cpp
@@ -1,0 +1,16 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#include "core.h"
+#include "tprfile.h"
+
+void gmxpy::detail::export_tprfile(pybind11::module &m)
+{
+    namespace py = pybind11;
+
+    // C++ may need to extend the life of a TprFile object provided by the Python
+    // interpreter, so we need a reference-counted holder.
+    py::class_<TprFile, std::shared_ptr<TprFile>> tprfile(m, "TprFile");
+    tprfile.def("__enter__", )
+}

--- a/src/gmx/core/mdcheckpoint.cpp
+++ b/src/gmx/core/mdcheckpoint.cpp
@@ -1,0 +1,6 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#include "mdcheckpoint.h"
+

--- a/src/gmx/core/mdcheckpoint.h
+++ b/src/gmx/core/mdcheckpoint.h
@@ -1,0 +1,16 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#ifndef GMXPY_MDCHECKPOINT_H
+#define GMXPY_MDCHECKPOINT_H
+
+namespace gmxpy
+{
+
+class MDCheckpoint
+{};
+
+}
+
+#endif //GMXPY_MDCHECKPOINT_H

--- a/src/gmx/core/microstate.cpp
+++ b/src/gmx/core/microstate.cpp
@@ -1,0 +1,5 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#include "microstate.h"

--- a/src/gmx/core/microstate.h
+++ b/src/gmx/core/microstate.h
@@ -1,0 +1,41 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#ifndef GMXPY_MICROSTATE_H
+#define GMXPY_MICROSTATE_H
+
+#include <memory>
+#include "tprfile.h"
+#include "mdcheckpoint.h"
+
+namespace gmxpy
+{
+
+class Microstate
+{};
+
+/*!
+ * \brief Get read access to the microstate corresponding to the provided input.
+ *
+ * When a TPR file and a checkpoint file are provided, the microstate returned is
+ * the configuration and simulation state corresponding to the checkpointed frame
+ * of the trajectory produced with the TPR file as input.
+ *
+ * \warning The current implementation does not rigorously check that the state
+ * in the checkpoint was actually produced by the TPR input, only that it is
+ * not incompatible with the simulation described in the TPR input.
+ *
+ * \param tprFile Handle to a TPR file object.
+ * \param checkpoint Handle to a simulation checkpoint object.
+ *
+ * \return Ownership of a new handle to the microstate.
+ *
+ * After the call completes, data has been read and the TprFile and MDCheckpoint
+ * are no longer needed by the returned Microstate.
+ */
+std::unique_ptr<Microstate> readMicrostate(const TprFile& tprFile, const MDCheckpoint& checkpoint);
+
+}
+
+#endif //GMXPY_MICROSTATE_H

--- a/src/gmx/core/tprfile.h
+++ b/src/gmx/core/tprfile.h
@@ -10,6 +10,9 @@
 namespace gmxpy
 {
 
+class TprFile
+{};
+
 /*!
  * \brief Copy and possibly update TPR file by name.
  *
@@ -19,8 +22,6 @@ namespace gmxpy
  * \return true if successful, else false
  */
 bool copy_tprfile(std::string infile, std::string outfile, double end_time);
-
-
 
 }
 

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -15,7 +15,23 @@ class TprTestCase(unittest.TestCase):
         self.assertRaises(UsageError, TprFile, tpr_filename, 'x')
         # TprFile does not yet check whether file exists and is readable...
         #self.assertRaises(UsageError, TprFile, 1, 'r')
-        fh = TprFile(tpr_filename, 'r')
+        tprfile = TprFile(tpr_filename, 'r')
+        with tprfile.extract() as fh:
+            pass
+
+class TprCoreTestCase(unittest.TestCase):
+    def test_gmxapiTprFile(self):
+        import gmx.core
+        api_object = gmx.core.TprFile(self.filename, mode='r')
+        with api_object as handle:
+            pass
+
+    def test_tprcopy(self):
+        _, temp_filename = tempfile.mkstemp(suffix='.tpr')
+        # When we have some more inspection tools we can do more than just check for success.
+        assert gmx.core.copy_tprfile(source=tpr_filename, destination=temp_filename, end_time=1.0)
+        os.unlink(temp_filename)
+
 
     def test_tprcopy(self):
         _, temp_filename = tempfile.mkstemp(suffix='.tpr')


### PR DESCRIPTION
work in progress

Add "end_time" keyword argument to from_tpr() function and clarify
behavior of `steps`. For 0.0.6, `end_time` is processed by the
`load_tpr` operation in `gmx.context`. For 0.0.7, a `modify_input` node
is inserted in the execution graph between the `load_tpr` and `md` nodes.
Later changes will insert additional work elements in the workflow, but
this can wait for schema 0.2. User interface is unchanged from 0.0.6.1.

The TPR file specified as the input source for the operation is copied
and updated by the framework in a temporary area as an implementation
detail. The original TPR file is left untouched.

API functionality tasks:

- [ ] Add TPR and checkpoint file objects to gmx.core
- [ ] Add "microstate" abstraction to gmx.core.
- [ ] Read nsteps from TPR
- [ ] Read current step from microstate
- [ ] set nsteps in TPR
- [ ] write new TPR file
- [ ] insert graph node to transform tpr file from source to tpr file with
  updated parameters for MD node

fixes #56 
fixes #86 
fixes #85 
fixes #158 
Refs #144 