### PR TITLE
Distinguish upstream GROMACS from kassonlab/gromacs-gmxapi.

### DIFF
--- a/RELEASE.txt
+++ b/RELEASE.txt
@@ -10,11 +10,17 @@ Similarly, update the `gromacs_url` embedded in setup.py
 After merging the gmxapi development branch to master and before tagging the release, 
 update version.in so that it writes a version.py file with `release = True`.
 
-Once the release is tagged and any touch-up commits are merged (fast-forwarded) to the refreshed development branch,
-bump the version in the development branch in CMakeLists.txt _and_ in setup.py. If / when feature branches
-require new libgmxapi features, `find_package(gmxapi...` can be updated in `src/gmx/core/CMakeLists.txt`. As of
-gromacs-gmxapi 0.0.6, we are tracking compatibility more closely, and the gromacs-gmxapi 0.0.7 development branch will
-claim compatibility with 0.0.6 if possible. Note that version compatibility in find_package is handled by the installed
+Once the gmxapi gmxpy release is tagged and any touch-up commits are merged (fast-forwarded) to the refreshed
+development branch,
+bump the version in the development branch in CMakeLists.txt _and_ in setup.py.
+
+If / when feature branches require new libgmxapi features, `find_package(gmxapi...` can be updated in
+`src/gmx/core/CMakeLists.txt`.
+
+As of gromacs-gmxapi 0.0.6, we are tracking compatibility more closely, and the gromacs-gmxapi 0.0.7 development branch
+will claim compatibility with 0.0.6 while possible.
+
+Note that version compatibility in find_package is handled by the installed
 cmake version file of the targeted package, including handling of the `EXACT` key word, but the CMake macros used in
 gromacs-gmxapi should take care of this.
 

--- a/src/gmx/core/CMakeLists.txt
+++ b/src/gmx/core/CMakeLists.txt
@@ -10,6 +10,18 @@
 find_package(gmxapi 0.0.6 REQUIRED
              HINTS "$ENV{GROMACS_DIR}"
              )
+if(gmxapi_FOUND)
+    set(_suffix "")
+    # GROMACS master branch and forked development branches may have divergent
+    # pre-release APIs. This check allows us to distinguish them and behave
+    # differently if needed. github.com/kassonlab/gromacs-gmxapi devel branch
+    # sets gmxapi_EXPERIMENTAL=TRUE. Upstream GROMACS master branch does not.
+    # Ref: https://github.com/kassonlab/gmxapi/issues/166
+    if(gmxapi_EXPERIMENTAL)
+        set(_suffix " (unofficial)")
+    endif()
+    message(STATUS "Found gmxapi version ${gmxapi_VERSION}${_suffix}")
+endif()
 
 # Build the C++ extension
 include_directories(${PYTHON_INCLUDE_DIRS})


### PR DESCRIPTION
Refs #166

* Use the CMake variable introduced in https://github.com/kassonlab/gromacs-gmxapi/pull/32
* Make a small CMake message that is useful to developers but not alarming to users.
* Update notes on managing new tagged releases.

Note: we do not yet need to use this feature so this change just establishes that we can check for it.