### PR TITLE
Reenable CI testing of sample_restraint.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,15 +72,15 @@ before_script:
 
 script:
   - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/pygmx.sh
-#  - ./ci_scripts/sample_restraint.sh v0.0.6
+#  - ./ci_scripts/sample_restraint.sh release-0_0_7
   - |
     if [ "${TRAVIS_BRANCH}" != master ] ; then
       source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/pygmx.sh
     fi
-#  - |
-#    if [ "${TRAVIS_BRANCH}" != master ] ; then
-#      ./ci_scripts/sample_restraint.sh devel
-#    fi
+  - |
+    if [ "${TRAVIS_BRANCH}" != master ] ; then
+      ./ci_scripts/sample_restraint.sh devel
+    fi
 
 # At some point, we should test more types of interactions between components, such as both static and dynamically
 # linked builds, and components built with different compilers.


### PR DESCRIPTION
Resume building and testing sample_restraint devel branch on Travis-CI in preparation for 0.0.7 release.