### PR TITLE
Reduce coupling to networkx

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,5 @@
 cmake>=0.8.0
-docutils>=0.13.1
-networkx>=2.0
 pip>=10.1
-py>=1.4.34
 Pygments>=2.2.0
 setuptools>=28.0.0
 scikit-build>=0.7


### PR DESCRIPTION
We currently require networkx to execute graphs, but we shouldn't
require it for type definitions or to build documentation. Import only
where needed and raise appropriate exception when missing.