### PR TITLE
Basic TPR reader

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -76,6 +76,12 @@ produces a :class:`Session` object. See examples below.
 
     :class:`Session` is not well specified in gmxapi 0.0.6.
 
+gmx.fileio module
+-----------------
+
+..  automodule:: gmx.fileio
+    :members:
+
 gmx.system module
 -----------------
 

--- a/src/gmx/core/CMakeLists.txt
+++ b/src/gmx/core/CMakeLists.txt
@@ -7,6 +7,7 @@ pybind11_add_module(pygmx_core
                     export_md.cpp
                     export_system.cpp
                     pycontext.cpp
+                    export_tprfile.cpp
                     pymdmodule.cpp
                     pysystem.cpp
                     tprfile.cpp

--- a/src/gmx/core/core.cpp
+++ b/src/gmx/core/core.cpp
@@ -73,14 +73,12 @@ PYBIND11_MODULE(core, m) {
 
 
     // Get bindings exported by the various components.
+    // In the current implementation, sequence may be important. Exports that
+    // reference bindings from other exports should not be called before the
+    // dependencies are exported.
+    export_tprfile(m);
     export_md(m);
     export_context(m);
     export_system(m);
 
-    m.def("copy_tprfile",
-            &gmxpy::copy_tprfile,
-            py::arg("source"),
-            py::arg("destination"),
-            py::arg("end_time"),
-            "Copy a TPR file from `source` to `destination`, replacing `nsteps` with `end_time`.");
 }

--- a/src/gmx/core/core.h
+++ b/src/gmx/core/core.h
@@ -35,6 +35,8 @@ void export_context(pybind11::module &m);
 
 void export_system(pybind11::module &m);
 
+void export_tprfile(pybind11::module &m);
+
 } // end namespace gmxpy::detail
 
 }      // end namespace gmxpy

--- a/src/gmx/core/export_tprfile.cpp
+++ b/src/gmx/core/export_tprfile.cpp
@@ -4,6 +4,7 @@
 
 #include "core.h"
 #include "tprfile.h"
+#include <pybind11/stl.h>
 
 namespace gmxpy {
 
@@ -14,6 +15,11 @@ void detail::export_tprfile(pybind11::module &m)
     using gmxapicompat::readTprFile;
 
     py::class_<TprFileHandle> tprfile(m, "TprFile");
+    tprfile.def("params",
+            [](const TprFileHandle& self)
+            {
+                return gmxapicompat::keys(gmxapicompat::getMdParams(self));
+            });
 
     m.def("read_tprfile",
             &readTprFile,

--- a/src/gmx/core/export_tprfile.cpp
+++ b/src/gmx/core/export_tprfile.cpp
@@ -18,7 +18,21 @@ void detail::export_tprfile(pybind11::module &m)
     tprfile.def("params",
             [](const TprFileHandle& self)
             {
-                return gmxapicompat::keys(gmxapicompat::getMdParams(self));
+                py::dict dictionary;
+                auto params = gmxapicompat::getMdParams(self);
+                for (const auto& key : gmxapicompat::keys(params))
+                {
+                    const auto& paramType = gmxapicompat::mdParamToType(key);
+                    if (gmxapicompat::isFloat(paramType))
+                    {
+                        dictionary[key.c_str()] = extractParam(params, key, double());
+                    }
+                    else if (gmxapicompat::isInt(paramType))
+                    {
+                        dictionary[key.c_str()] = extractParam(params, key, int64_t());
+                    }
+                }
+                return dictionary;
             });
 
     m.def("read_tprfile",

--- a/src/gmx/core/export_tprfile.cpp
+++ b/src/gmx/core/export_tprfile.cpp
@@ -7,18 +7,18 @@
 
 namespace gmxpy {
 
-class PyTprFileHandle
-{
-    // C++ may need to extend the life of a TprFile object provided by the Python
-    // interpreter, so we use a reference-counted holder.
-    std::shared_ptr<TprFileHandle> filehandle_;
-};
-
 void detail::export_tprfile(pybind11::module &m)
 {
     namespace py = pybind11;
+    using gmxapicompat::TprFileHandle;
+    using gmxapicompat::readTprFile;
 
-    py::class_<PyTprFileHandle> tprfile(m, "TprFile");
+    py::class_<TprFileHandle> tprfile(m, "TprFile");
+
+    m.def("read_tprfile",
+            &readTprFile,
+            py::arg("filename"),
+            "Get a handle to a TPR file resource for a given file name.");
 
     m.def("copy_tprfile",
           &gmxpy::copy_tprfile,

--- a/src/gmx/core/export_tprfile.cpp
+++ b/src/gmx/core/export_tprfile.cpp
@@ -1,0 +1,31 @@
+//
+// Created by Eric Irrgang on 8/10/18.
+//
+
+#include "core.h"
+#include "tprfile.h"
+
+namespace gmxpy {
+
+class PyTprFileHandle
+{
+    // C++ may need to extend the life of a TprFile object provided by the Python
+    // interpreter, so we use a reference-counted holder.
+    std::shared_ptr<TprFileHandle> filehandle_;
+};
+
+void detail::export_tprfile(pybind11::module &m)
+{
+    namespace py = pybind11;
+
+    py::class_<PyTprFileHandle> tprfile(m, "TprFile");
+
+    m.def("copy_tprfile",
+          &gmxpy::copy_tprfile,
+          py::arg("source"),
+          py::arg("destination"),
+          py::arg("end_time"),
+          "Copy a TPR file from `source` to `destination`, replacing `nsteps` with `end_time`.");
+}
+
+} // end namespace gmxpy

--- a/src/gmx/core/mdparams.h
+++ b/src/gmx/core/mdparams.h
@@ -103,8 +103,8 @@ public:
     ~GmxMdParams();
     GmxMdParams(const GmxMdParams&) = delete;
     GmxMdParams& operator=(const GmxMdParams&) = delete;
-    GmxMdParams(GmxMdParams&&) = default;
-    GmxMdParams& operator=(GmxMdParams&&) = default;
+    GmxMdParams(GmxMdParams&&) noexcept;
+    GmxMdParams& operator=(GmxMdParams&&) noexcept;
 
     std::unique_ptr<GmxMdParamsImpl> params_;
 };
@@ -126,6 +126,22 @@ double extractParam(const gmxapicompat::GmxMdParams& params, const std::string& 
 
 void setParam(gmxapicompat::GmxMdParams* params, const std::string& name, double value);
 void setParam(gmxapicompat::GmxMdParams* params, const std::string& name, int64_t value);
+
+// Anonymous namespace to confine helper function definitions to file scope.
+namespace
+{
+
+bool isFloat(GmxapiType dataType)
+{
+    return (dataType == GmxapiType::gmxFloat64) || (dataType == GmxapiType::gmxFloat32);
+}
+
+bool isInt(GmxapiType dataType)
+{
+    return (dataType == GmxapiType::gmxInt64) || (dataType == GmxapiType::gmxInt32);
+}
+
+} // end anonymous namespace
 
 } // end namespace gmxapicompat
 

--- a/src/gmx/core/mdparams.h
+++ b/src/gmx/core/mdparams.h
@@ -1,0 +1,112 @@
+#ifndef GMXPY_MDPARAMS_H
+#define GMXPY_MDPARAMS_H
+
+/*! \file
+ * \brief Compatibility header for functionality differences in gmxapi releases.
+ *
+ * Also handle the transitioning installed headers from GROMACS 2019 moving forward.
+ *
+ * \todo Configure for gmxapi 0.0.7, 0.0.8, GROMACS 2019, GROMACS master...
+ *
+ * \defgroup gmxapi_compat
+ * \ingroup gmxapi_compat
+ */
+
+#include <map>
+#include <string>
+
+struct t_inputrec;
+
+/*!
+ * \brief Compatibility code for features that may not be in gmxapi yet.
+ */
+namespace gmxapicompat
+{
+
+
+/*!
+ * \brief Label the types recognized by gmxapi.
+ *
+ * Provide an enumeration to aid in translating data between languages, APIs,
+ * and storage formats.
+ *
+ * \todo The spec should explicitly map these to types in APIs already used.
+ * e.g. MPI, Python, numpy, GROMACS, JSON, etc.
+ * \todo Actually check the size of the types.
+ */
+enum class GmxapiType {
+    gmxNull, //! Reserved
+    gmxMap, //! Mapping of key name (string) to a value of some MdParamType
+    gmxBool, //! Boolean logical type
+    gmxInt32, //! 32-bit integer type, initially unused
+    gmxInt64, //! 64-bit integer type
+    gmxFloat32, //! 32-bit float type, initially unused
+    gmxFloat64, //! 64-bit float type
+    gmxString, //! string with metadata
+    gmxMDArray, //! multi-dimensional array with metadata
+// Might be appropriate to have convenience types for small non-scalars that
+// shouldn't need metadata.
+//    gmxFloat32Vector3, //! 3 contiguous 32-bit floating point values.
+//    gmxFloat32SquareMatrix3, //! 9 contiguous 32-bit FP values in row-major order.
+};
+
+
+/*!
+ * \brief Static map of GROMACS 2019 mdp file entries to normalized "type".
+ *
+ * \return
+ */
+const std::map<std::string, GmxapiType> simulationParameterTypeMap();
+
+const std::map<std::string, bool t_inputrec::*> boolParams();
+const std::map<std::string, int t_inputrec::*> int32Params();
+const std::map<std::string, float t_inputrec::*> float32Params();
+const std::map<std::string, double t_inputrec::*> float64Params();
+const std::map<std::string, int64_t t_inputrec::*> int64Params();
+
+/*!
+ * \brief Static mapping of parameter names to gmxapi types for GROMACS 2019.
+ *
+ * \param name MDP entry name.
+ * \return enumeration value for known parameters.
+ *
+ * \throws gmxapi_compat::ValueError for parameters with no mapping.
+ */
+GmxapiType mdParamToType(const std::string& name);
+
+/*!
+ * \brief Handle / manager for GROMACS MM computation input parameters.
+ *
+ * Interface should be consistent with MDP file entries, but data maps to TPR
+ * file interface. For type safety and simplicity, we don't have generic operator
+ * accessors. Instead, we have templated accessors that throw exceptions when
+ * there is trouble.
+ *
+ * When MDP input is entirely stored in a key-value tree, this class can be a
+ * simple adapter or wrapper. Until then, we need a manually maintained mapping
+ * of MDP entries to TPR data.
+ *
+ * Alternatively, we could update the infrastructure used by list_tpx to provide
+ * more generic output, but our efforts may be better spent in updating the
+ * infrastructure for the key-value tree input system.
+ */
+class GmxMdParams;
+
+/*!
+ * \brief A set of overloaded functions to fetch parameters of the indicated type, if possible.
+ *
+ * \param params Handle to a parameters structure from which to extract.
+ * \param name Parameter name
+ * \param
+ *
+ * Could be used for dispatch and/or some sort of templating in the future, but
+ * invoked directly for now.
+ */
+int extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, int);
+int64_t extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, int64_t);
+float extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, float);
+double extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, double);
+
+} // end namespace gmxapicompat
+
+#endif //GMXPY_MDPARAMS_H

--- a/src/gmx/core/mdparams.h
+++ b/src/gmx/core/mdparams.h
@@ -74,6 +74,9 @@ const std::map<std::string, int64_t t_inputrec::*> int64Params();
  */
 GmxapiType mdParamToType(const std::string& name);
 
+// Forward declaration for private implementation class for GmxMdParams
+class GmxMdParamsImpl;
+
 /*!
  * \brief Handle / manager for GROMACS MM computation input parameters.
  *
@@ -90,7 +93,18 @@ GmxapiType mdParamToType(const std::string& name);
  * more generic output, but our efforts may be better spent in updating the
  * infrastructure for the key-value tree input system.
  */
-class GmxMdParams;
+class GmxMdParams
+{
+public:
+    GmxMdParams() = default;
+    ~GmxMdParams();
+    GmxMdParams(const GmxMdParams&) = delete;
+    GmxMdParams& operator=(const GmxMdParams&) = delete;
+    GmxMdParams(GmxMdParams&&) = default;
+    GmxMdParams& operator=(GmxMdParams&&) = default;
+
+    std::unique_ptr<GmxMdParamsImpl> params_;
+};
 
 /*!
  * \brief A set of overloaded functions to fetch parameters of the indicated type, if possible.

--- a/src/gmx/core/mdparams.h
+++ b/src/gmx/core/mdparams.h
@@ -13,7 +13,10 @@
  */
 
 #include <map>
+#include <memory>
 #include <string>
+
+#include "exceptions.h"
 
 struct t_inputrec;
 
@@ -96,7 +99,7 @@ class GmxMdParamsImpl;
 class GmxMdParams
 {
 public:
-    GmxMdParams() = default;
+    GmxMdParams();
     ~GmxMdParams();
     GmxMdParams(const GmxMdParams&) = delete;
     GmxMdParams& operator=(const GmxMdParams&) = delete;
@@ -120,6 +123,9 @@ int extractParam(const gmxapicompat::GmxMdParams& params, const std::string& nam
 int64_t extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, int64_t);
 float extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, float);
 double extractParam(const gmxapicompat::GmxMdParams& params, const std::string& name, double);
+
+void setParam(gmxapicompat::GmxMdParams* params, const std::string& name, double value);
+void setParam(gmxapicompat::GmxMdParams* params, const std::string& name, int64_t value);
 
 } // end namespace gmxapicompat
 

--- a/src/gmx/core/tprfile.cpp
+++ b/src/gmx/core/tprfile.cpp
@@ -7,6 +7,10 @@
 
 #include "tprfile.h"
 
+#include <map>
+#include <memory>
+#include <string>
+
 #include "gromacs/mdtypes/inputrec.h"
 #include "gromacs/topology/topology.h"
 #include "gromacs/mdtypes/state.h"
@@ -17,8 +21,324 @@
 #include "gromacs/utility/cstringutil.h"
 #include "gromacs/utility/programcontext.h"
 
+#include "exceptions.h"
+#include "mdparams.h"
 
-bool gmxpy::copy_tprfile(std::string infile, std::string outfile, double until_t) {
+namespace gmxapicompat
+{
+
+
+/*!
+ * \brief Static map of GROMACS 2019 mdp file entries to normalized "type".
+ *
+ * \return
+ */
+const std::map<std::string, GmxapiType> simulationParameterTypeMap()
+{
+    return {
+            {"integrator", GmxapiType::gmxString},
+            {"tinit",      GmxapiType::gmxFloat64},
+            {"dt",         GmxapiType::gmxFloat64},
+            {"nsteps",     GmxapiType::gmxInt64},
+            {"init-step",     GmxapiType::gmxInt64},
+            {"simulation-part",     GmxapiType::gmxInt64},
+            {"comm-mode",     GmxapiType::gmxString},
+            {"nstcomm",     GmxapiType::gmxInt64},
+            {"comm-grps",     GmxapiType::gmxMDArray}, // Note: we do not have processing for this yet.
+            {"bd-fric",     GmxapiType::gmxFloat64},
+            {"ld-seed",     GmxapiType::gmxInt64},
+            {"emtol",     GmxapiType::gmxFloat64},
+            {"emstep",     GmxapiType::gmxFloat64},
+            {"niter",     GmxapiType::gmxInt64},
+            {"fcstep",     GmxapiType::gmxFloat64},
+            {"nstcgsteep",     GmxapiType::gmxInt64},
+            {"nbfgscorr",     GmxapiType::gmxInt64},
+            {"rtpi",     GmxapiType::gmxFloat64},
+            {"nstxout",     GmxapiType::gmxInt64},
+            {"nstvout",     GmxapiType::gmxInt64},
+            {"nstfout",     GmxapiType::gmxInt64},
+            {"nstlog",     GmxapiType::gmxInt64},
+            {"nstcalcenergy",     GmxapiType::gmxInt64},
+            {"nstenergy",     GmxapiType::gmxInt64},
+            {"nstxout-compressed",     GmxapiType::gmxInt64},
+            {"compressed-x-precision",     GmxapiType::gmxFloat64},
+//            {"compressed-x-grps",     GmxapiType::gmxMDArray},
+//            {"energygrps",     GmxapiType::gmxInt64},
+            {"cutoff-scheme",     GmxapiType::gmxString},
+            {"nstlist",     GmxapiType::gmxInt64},
+            {"ns-type",     GmxapiType::gmxString},
+            {"pbc",     GmxapiType::gmxString},
+            {"periodic-molecules",     GmxapiType::gmxBool},
+//            ...
+
+    };
+};
+
+/*
+ * Visitor for predetermined known types.
+ *
+ * Development sequence:
+ * 1. map pointers
+ * 2. map setters ()
+ * 3. template the Visitor setter for compile-time extensibility of type and to prune incompatible types.
+ * 4. switch to Variant type for handling (setter templated on caller input)
+ * 5. switch to Variant type for input as well? (Variant in public API?)
+ */
+
+const std::map<std::string, bool t_inputrec::*> boolParams()
+{
+    return {
+            {"periodic-molecules", &t_inputrec::bPeriodicMols},
+//            ...
+    };
+}
+
+const std::map<std::string, int t_inputrec::*> int32Params()
+{
+    return {
+            {"simulation-part",     &t_inputrec::simulation_part},
+            {"nstcomm",     &t_inputrec::nstcomm},
+            {"niter",     &t_inputrec::niter},
+            {"nstcgsteep",     &t_inputrec::nstcgsteep},
+            {"nbfgscorr",     &t_inputrec::nbfgscorr},
+            {"nstxout",     &t_inputrec::nstxout},
+            {"nstvout",     &t_inputrec::nstvout},
+            {"nstfout",     &t_inputrec::nstfout},
+            {"nstlog",     &t_inputrec::nstlog},
+            {"nstcalcenergy",     &t_inputrec::nstcalcenergy},
+            {"nstenergy",     &t_inputrec::nstenergy},
+            {"nstxout-compressed",     &t_inputrec::nstxout_compressed},
+            {"nstlist",     &t_inputrec::nstlist},
+//            ...
+    };
+}
+
+const std::map<std::string, float t_inputrec::*> float32Params()
+{
+    return {
+            {"bd-fric",     &t_inputrec::bd_fric},
+            {"emtol",     &t_inputrec::em_tol},
+            {"emstep",     &t_inputrec::em_stepsize},
+            {"fcstep",     &t_inputrec::fc_stepsize},
+            {"rtpi",     &t_inputrec::rtpi},
+            {"compressed-x-precision",     &t_inputrec::x_compression_precision},
+//            ...
+
+    };
+}
+const std::map<std::string, double t_inputrec::*> float64Params()
+{
+    return {
+            {"dt", &t_inputrec::delta_t},
+            {"tinit", &t_inputrec::init_t},
+//            ...
+
+    };
+}
+const std::map<std::string, int64_t t_inputrec::*> int64Params()
+{
+    return {
+            {"nsteps",     &t_inputrec::nsteps},
+            {"init-step",     &t_inputrec::init_step},
+            {"ld-seed",     &t_inputrec::ld_seed},
+//            ...
+
+    };
+}
+
+/*!
+ * \brief Static mapping of parameter names to gmxapi types for GROMACS 2019.
+ *
+ * \param name MDP entry name.
+ * \return enumeration value for known parameters.
+ *
+ * \throws gmxapi_compat::ValueError for parameters with no mapping.
+ */
+GmxapiType mdParamToType(const std::string& name)
+{
+    const auto staticMap = simulationParameterTypeMap();
+    auto entry = staticMap.find(name);
+    if(entry == staticMap.end())
+    {
+        throw ValueError("Named parameter has unknown type mapping.");
+    }
+    return entry->second;
+};
+
+
+/*!
+ * \brief Handle / manager for GROMACS MM computation input parameters.
+ *
+ * Interface should be consistent with MDP file entries, but data maps to TPR
+ * file interface. For type safety and simplicity, we don't have generic operator
+ * accessors. Instead, we have templated accessors that throw exceptions when
+ * there is trouble.
+ *
+ * When MDP input is entirely stored in a key-value tree, this class can be a
+ * simple adapter or wrapper. Until then, we need a manually maintained mapping
+ * of MDP entries to TPR data.
+ *
+ * Alternatively, we could update the infrastructure used by list_tpx to provide
+ * more generic output, but our efforts may be better spent in updating the
+ * infrastructure for the key-value tree input system.
+ */
+class GmxMdParams final
+{
+public:
+    /*!
+     * \brief Create an initialized but empty parameters structure.
+     *
+     * Parameter keys are set at construction, but all values are empty. This
+     * allows the caller to check for valid parameter names or their types,
+     * while allowing the consuming code to know which parameters were explicitly
+     * set by the caller.
+     *
+     * To load values from a TPR file, see getMdParams().
+     */
+//    GmxMdParams();
+
+    /*!
+     * \brief Get the current list of keys.
+     *
+     * \return
+     */
+    std::vector<std::string> keys() const
+    {
+        std::vector<std::string> keyList;
+        for (auto&& entry : int64Params_)
+        {
+            keyList.emplace_back(entry.first);
+        }
+        for (auto&& entry : floatParams_)
+        {
+            keyList.emplace_back(entry.first);
+        }
+        return keyList;
+    };
+
+    template<typename T> T extract(const std::string& key) const
+    {
+        auto value = T();
+        // should be an APIError
+        throw TypeError("unhandled type");
+    }
+
+private:
+    // TODO: update to gmxapi named types?
+    std::map<std::string, int64_t t_inputrec::*> int64Params_;
+    std::map<std::string, int t_inputrec::*> intParams_;
+    std::map<std::string, float t_inputrec::*> floatParams_;
+    std::map<std::string, double t_inputrec::*> float64Params_;
+    // t_inputrec requires libgromacs to construct or destroy.
+    t_inputrec inputRecord_;
+};
+
+template<>
+int GmxMdParams::extract<int>(const std::string& key) const {
+    const auto& params = intParams_;
+    const auto& entry = params.find(key);
+    if (entry == params.cend())
+    {
+        throw KeyError("Parameter of the requested name and type not available.");
+    }
+    else
+    {
+        const auto& dataMemberPointer = entry->second;
+        return inputRecord_.*dataMemberPointer;
+    }
+}
+template<>
+int64_t GmxMdParams::extract<int64_t>(const std::string& key) const {
+    const auto& params = int64Params_;
+    const auto& entry = params.find(key);
+    if (entry == params.cend())
+    {
+        throw KeyError("Parameter of the requested name and type not available.");
+    }
+    else
+    {
+        const auto& dataMemberPointer = entry->second;
+        return inputRecord_.*dataMemberPointer;
+    }
+}
+template<>
+float GmxMdParams::extract<float>(const std::string& key) const {
+    const auto& params = floatParams_;
+    const auto& entry = params.find(key);
+    if (entry == params.cend())
+    {
+        throw KeyError("Parameter of the requested name and type not available.");
+    }
+    else
+    {
+        const auto& dataMemberPointer = entry->second;
+        return inputRecord_.*dataMemberPointer;
+    }
+}
+template<>
+double GmxMdParams::extract<double>(const std::string& key) const {
+    const auto& params = float64Params_;
+    const auto& entry = params.find(key);
+    if (entry == params.cend())
+    {
+        throw KeyError("Parameter of the requested name and type not available.");
+    }
+    else
+    {
+        const auto& dataMemberPointer = entry->second;
+        return inputRecord_.*dataMemberPointer;
+    }
+}
+
+class TprFile
+{
+public:
+    explicit TprFile(const std::string& infile) :
+        irInstance{std::make_unique<t_inputrec>()},
+        mtop{std::make_unique<gmx_mtop_t>()},
+        state{std::make_unique<t_state>()}
+    {
+        t_inputrec *ir = irInstance.get();
+        read_tpx_state(infile.c_str(), ir, state.get(), mtop.get());
+    }
+    ~TprFile() = default;
+    TprFile(TprFile&& source) noexcept = default;
+    TprFile& operator=(TprFile&&) noexcept = default;
+
+private:
+    // These types are not moveable in GROMACS 2019, so we use unique_ptr as a
+    // moveable wrapper to let TprFile be moveable.
+    std::unique_ptr<t_inputrec>  irInstance;
+    std::unique_ptr<gmx_mtop_t>        mtop;
+    std::unique_ptr<t_state>           state;
+
+};
+
+TprFileHandle readTprFile(const std::string& filename) {
+    auto tprfile = gmxapicompat::TprFile(filename);
+    auto handle = gmxapicompat::TprFileHandle(std::move(tprfile));
+    return handle;
+}
+
+TprFileHandle::TprFileHandle(std::shared_ptr<TprFile> tprFile) :
+    tprFile_{std::move(tprFile)}
+{
+}
+
+TprFileHandle::TprFileHandle(TprFile &&tprFile) :
+    TprFileHandle{std::make_shared<TprFile>(std::move(tprFile))}
+{
+}
+
+// defaulted here to delay definition until after member types are defined.
+TprFileHandle::~TprFileHandle() = default;
+
+} // end namespace gmxapicompat
+
+namespace gmxpy
+{
+
+bool copy_tprfile(std::string infile, std::string outfile, double until_t) {
     bool success = false;
 
     const char * top_fn = infile.c_str();
@@ -55,3 +375,5 @@ bool gmxpy::copy_tprfile(std::string infile, std::string outfile, double until_t
     success = true;
     return success;
 }
+
+} // end namespace gmxpy

--- a/src/gmx/core/tprfile.cpp
+++ b/src/gmx/core/tprfile.cpp
@@ -7,9 +7,12 @@
 
 #include "tprfile.h"
 
+#include <cassert>
+
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "gromacs/mdtypes/inputrec.h"
 #include "gromacs/topology/topology.h"
@@ -397,8 +400,62 @@ double GmxMdParamsImpl::extract<double>(const std::string& key) const {
 }
 
 
+int extractParam(const GmxMdParams &params, const std::string &name, int) {
+    assert(params.params_);
+    return params.params_->extract<int>(name);
+}
 
-std::vector<std::string> keys(const gmxapicompat::GmxMdParams &params) {
+int64_t extractParam(const GmxMdParams &params, const std::string &name, int64_t) {
+    assert(params.params_);
+    int64_t value{};
+    // Allow fetching both known integer types.
+    try {
+        value = params.params_->extract<int>(name);
+    }
+    catch (const KeyError& error)
+    {
+        // If not found as a regular int, check for int64.
+        try {
+            value = params.params_->extract<int64_t >(name);
+        }
+        catch (const KeyError& error64)
+        {
+            throw KeyError("Parameter of the requested name not set.");
+        }
+    }
+    // Any other exceptions propagate out.
+    return value;
+}
+
+float extractParam(const GmxMdParams &params, const std::string &name, float) {
+    assert(params.params_);
+    return params.params_->extract<float>(name);
+}
+
+double extractParam(const GmxMdParams &params, const std::string &name, double) {
+    assert(params.params_);
+    double value{};
+    // Allow fetching both single and double precision.
+    try {
+        value = params.params_->extract<double>(name);
+    }
+    catch (const KeyError& errorDouble)
+    {
+        // If not found as a double precision value, check for single-precision.
+        try {
+            value = params.params_->extract<float>(name);
+        }
+        catch (const KeyError& errorFloat)
+        {
+            throw KeyError("Parameter of the requested name not set.");
+        }
+    }
+    // Any other exceptions propagate out.
+    return value;
+}
+
+
+std::vector<std::string> keys(const GmxMdParams &params) {
     return params.params_->keys();
 }
 
@@ -494,6 +551,10 @@ GmxMdParams::~GmxMdParams() = default;
 GmxMdParams::GmxMdParams() :
     params_{std::make_unique<GmxMdParamsImpl>()}
 {}
+
+GmxMdParams::GmxMdParams(GmxMdParams &&) noexcept = default;
+
+GmxMdParams &GmxMdParams::operator=(GmxMdParams &&) noexcept = default;
 
 } // end namespace gmxapicompat
 

--- a/src/gmx/core/tprfile.h
+++ b/src/gmx/core/tprfile.h
@@ -10,8 +10,193 @@
 
 #include <string>
 
+#include "exceptions.h"
+#include "mdparams.h"
+
+namespace gmxapicompat {
+
+/*!
+ * \brief Facade for objects that can provide atomic data for a configuration.
+ */
+class StructureSource;
+
+/*!
+ * \brief Facade for objects that can provide molecular topology information for a structure.
+ */
+class TopologySource;
+
+/*!
+ * \brief Proxy to simulation state data.
+ */
+class SimulationState;
+
+/*!
+ * \brief Manager for TPR file resources.
+ *
+ * Manager object should be shared by all users of resource associated with a
+ * particular file.
+ *
+ * Multiple read-only handles may be issued if there are no write-handles.
+ * One write handle may be issued if there are no other open handles.
+ *
+ * A const TprFile may only issue read file-handles, allowing handles to be
+ * issued more quickly by avoiding atomic resource locking.
+ *
+ * \note Shared ownership of file manager could be avoided if owned by a Context.
+ * It is appropriate for a Context to own and mediate access to the manager because
+ * it provides the filesystem abstraction and in order to more intelligently
+ * map named file paths to resources. For now, TprFileHandles share ownership
+ * of the TprFile manager object via shared_ptr.
+ */
+class TprFile;
+
+/*!
+ * \brief Handle for a TPR file resource.
+ *
+ * Can provide StructureSource, TopologySource, GmxMdParams, and SimulationState
+ */
+class TprFileHandle
+{
+public:
+    explicit TprFileHandle(std::shared_ptr<TprFile> tprFile);
+    explicit TprFileHandle(TprFile&& tprFile);
+    ~TprFileHandle();
+private:
+    std::shared_ptr<TprFile> tprFile_;
+};
+
+TprFileHandle readTprFile(const std::string& filename);
+
+/*!
+ * \brief
+ * \param filehandle
+ * \return
+ *
+ * \todo replace with a helper template on T::topologySource() member function existence.
+ */
+
+TopologySource getTopologySource(const TprFileHandle& filehandle);
+
+/*!
+ * \brief
+ * \param filehandle
+ * \return
+ *
+ * \todo template on T::simulationState() member function existence.
+ */
+SimulationState getSimulationState(const TprFileHandle& filehandle);
+
+StructureSource getStructureSource(const TprFileHandle& filehandle);
+
+/*!
+ * \brief Get an initialized parameters structure.
+ * \param fileHandle
+ * \return
+ */
+gmxapicompat::GmxMdParams getMdParams(const TprFileHandle& fileHandle);
+
+// Anonymous namespace for a template that we want to define at file scope.
+namespace {
+/*!
+ * \brief Procedural interface for setting named parameters.
+ *
+ * \throws TypeError if parameter and value are of incompatible type.
+ * \throws KeyError if parameter is unknown.
+ *
+ * \note The logic of errors is potentially confusing.
+ */
+template<typename T>
+gmxapicompat::GmxMdParams &setParam(gmxapicompat::GmxMdParams *params,
+                                    std::string keyname,
+                                    T value) {
+    const auto paramType = gmxapicompat::mdParamToType(keyname);
+    if (paramType == gmxapicompat::GmxapiType::gmxInt64) {
+
+    } else {
+        // If parameter type is registered and we don't have handler code, this is a bug.
+        assert(paramType == gmxapicompat::GmxapiType::gmxNull);
+        throw gmxapicompat::KeyError(std::string("Unknown parameter name: ") + keyname);
+    }
+    return *params;
+}
+} // end anonymous namespace
+
+///*!
+// * \brief Extract a parameter to the requested type.
+// *
+// * \tparam T
+// * \param params
+// * \param name
+// * \return
+// *
+// * \throws KeyError if parameter cannot be mapped.
+// * \throws TypeError if parameter type cannot be converted to T.
+// */
+//template<typename T>
+//T extractParam(const gmxapi_compat::GmxMdParams& params, const std::string& name)
+//{
+//    gmxapi_compat::GmxapiType paramType;
+//    try
+//    {
+//        paramType = gmxapi_compat::mdParamToType(name);
+//    }
+//    catch(const gmxapi_compat::ValueError& e)
+//    {
+//        throw gmxapi_compat::KeyError("No parameter entry for this name and type.");
+//    }
+//
+//    // If
+//    if (paramType)
+//    {}
+//    else
+//    {}
+//
+//    return {};
+//}
+
+} // end namespace gmxapicompat
+
 namespace gmxpy
 {
+/*!
+ * \brief Get a dictionary of MDP key-value pairs from a TPR file.
+ *
+ * \param filename TPR file name
+ *
+ * \return key-value pairs from filename
+ *
+ * \todo Move this to gmxapicompat to provide abstraction for different versions.
+ * * handle GROMACS 2019, GROMACS master with and without feature
+ * * handle TPR versions from GROMACS 2018 and later
+ */
+//pybind11::dict read_mdparams(const std::string &filename) {
+//    using namespace pybind11::literals; // to bring in the `_a` literal
+//
+//    const char *topology_filename = filename.c_str();
+//    t_inputrec irInstance;
+//    t_inputrec *ir = &irInstance;
+//    gmx_mtop_t mtop;
+//    t_state state;
+//    read_tpx_state(topology_filename, ir, &state, &mtop);
+//
+//    return pybind11::dict("nsteps"_a = ir->nsteps);
+//}
+
+/*!
+ * \brief Write a TPR file using the provided input.
+ *
+ * \param filename output file name.
+ * \param parameters GROMACS input parameters
+ * \param structure atomic configuration
+ * \param topology molecular topology information
+ */
+//void write_tpr(const std::string &filename,
+//               pybind11::dict parameters,
+//               const StructureSource &structureSource,
+//               const TopologySource &topology) {
+//
+//    write_tpx_state(filename.c_str(), ir, &state, &mtop);
+//}
 
 /*!
  * \brief Copy and possibly update TPR file by name.

--- a/src/gmx/core/tprfile.h
+++ b/src/gmx/core/tprfile.h
@@ -9,6 +9,7 @@
 #define GMXPY_TPRFILE_H
 
 #include <string>
+#include <vector>
 
 #include "exceptions.h"
 #include "mdparams.h"

--- a/src/gmx/core/tprfile.h
+++ b/src/gmx/core/tprfile.h
@@ -99,31 +99,6 @@ GmxMdParams getMdParams(const TprFileHandle& fileHandle);
 
 std::vector<std::string> keys(const GmxMdParams& params);
 
-// Anonymous namespace for a template that we want to define at file scope.
-namespace {
-/*!
- * \brief Procedural interface for setting named parameters.
- *
- * \throws TypeError if parameter and value are of incompatible type.
- * \throws KeyError if parameter is unknown.
- *
- * \note The logic of errors is potentially confusing.
- */
-template<typename T>
-gmxapicompat::GmxMdParams &setParam(gmxapicompat::GmxMdParams *params,
-                                    std::string keyname,
-                                    T value) {
-    const auto paramType = gmxapicompat::mdParamToType(keyname);
-    if (paramType == gmxapicompat::GmxapiType::gmxInt64) {
-
-    } else {
-        // If parameter type is registered and we don't have handler code, this is a bug.
-        assert(paramType == gmxapicompat::GmxapiType::gmxNull);
-        throw gmxapicompat::KeyError(std::string("Unknown parameter name: ") + keyname);
-    }
-    return *params;
-}
-} // end anonymous namespace
 
 ///*!
 // * \brief Extract a parameter to the requested type.

--- a/src/gmx/core/tprfile.h
+++ b/src/gmx/core/tprfile.h
@@ -61,6 +61,8 @@ public:
     explicit TprFileHandle(std::shared_ptr<TprFile> tprFile);
     explicit TprFileHandle(TprFile&& tprFile);
     ~TprFileHandle();
+
+    std::shared_ptr<TprFile> get() const ;
 private:
     std::shared_ptr<TprFile> tprFile_;
 };
@@ -93,7 +95,9 @@ StructureSource getStructureSource(const TprFileHandle& filehandle);
  * \param fileHandle
  * \return
  */
-gmxapicompat::GmxMdParams getMdParams(const TprFileHandle& fileHandle);
+GmxMdParams getMdParams(const TprFileHandle& fileHandle);
+
+std::vector<std::string> keys(const GmxMdParams& params);
 
 // Anonymous namespace for a template that we want to define at file scope.
 namespace {

--- a/src/gmx/core/typetemplates.h
+++ b/src/gmx/core/typetemplates.h
@@ -1,0 +1,98 @@
+//
+// Created by Eric Irrgang on 11/26/18.
+//
+
+#ifndef GMXPY_TYPETEMPLATES_H
+#define GMXPY_TYPETEMPLATES_H
+
+
+#include <type_traits>
+
+#include "mdparams.h"
+
+namespace gmxapicompat {
+
+namespace traits {
+
+// These can be more than traits. We might as well make them named types.
+struct gmxNull {
+    static const GmxapiType value = GmxapiType::gmxNull;
+};
+struct gmxMap {
+    static const GmxapiType value = GmxapiType::gmxMap;
+};
+struct gmxInt32 {
+    static const GmxapiType value = GmxapiType::gmxInt32;
+};
+struct gmxInt64 {
+    static const GmxapiType value = GmxapiType::gmxInt64;
+};
+struct gmxFloat32 {
+    static const GmxapiType value = GmxapiType::gmxFloat32;
+};
+struct gmxFloat64 {
+    static const GmxapiType value = GmxapiType::gmxFloat64;
+};
+struct gmxBool {
+    static const GmxapiType value = GmxapiType::gmxBool;
+};
+struct gmxString {
+    static const GmxapiType value = GmxapiType::gmxString;
+};
+struct gmxMDArray {
+    static const GmxapiType value = GmxapiType::gmxMDArray;
+};
+//struct gmxFloat32Vector3 {
+//    static const GmxapiType value = GmxapiType::gmxFloat32Vector3;
+//};
+//struct gmxFloat32SquareMatrix3 {
+//    static const GmxapiType value = GmxapiType::gmxFloat32SquareMatrix3;
+//};
+
+} // end namespace traits
+
+// Use an anonymous namespace to restrict these template definitions to file scope.
+namespace {
+// Partial specialization of functions is not allowed, which makes the following tedious.
+// To-do: switch to type-based logic, struct templates, etc.
+template<typename T, size_t s>
+GmxapiType mapCppType() {
+    return GmxapiType::gmxNull;
+}
+
+template<typename T>
+GmxapiType mapCppType() {
+    return mapCppType<T, sizeof(T)>();
+};
+
+template<>
+GmxapiType mapCppType<bool>() {
+    return GmxapiType::gmxBool;
+}
+
+template<>
+GmxapiType mapCppType<int, 4>() {
+    return GmxapiType::gmxInt32;
+}
+
+template<>
+GmxapiType mapCppType<int, 8>() {
+    return GmxapiType::gmxInt64;
+};
+
+
+template<>
+GmxapiType mapCppType<float, 4>() {
+    return GmxapiType::gmxFloat32;
+}
+
+template<>
+GmxapiType mapCppType<double, 8>() {
+    return GmxapiType::gmxFloat64;
+};
+
+} // end anonymous namespace
+
+} // end namespace gmxapicompat
+
+#endif //GMXPY_TYPETEMPLATES_H

--- a/src/gmx/fileio.py
+++ b/src/gmx/fileio.py
@@ -13,6 +13,7 @@ import os
 
 __all__ = ['TprFile']
 
+import gmx.core
 from gmx.exceptions import UsageError
 
 _current_dir = os.getcwd()
@@ -57,7 +58,7 @@ class TprFile:
         return "gmx.fileio.TprFile('{}', '{}')".format(self.filename, self.mode)
 
     def __enter__(self):
-        # self._tprFileHandle = gmx.core.TprFile()
+        self._tprFileHandle = gmx.core.read_tprfile(self.filename)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):

--- a/src/gmx/fileio.py
+++ b/src/gmx/fileio.py
@@ -47,8 +47,22 @@ class TprFile:
         if mode != 'r':
             raise UsageError("TPR files only support read-only access.")
         self.filename = filename
+        self._tprFileHandle = None
+
+    def close(self):
+        # self._tprFileHandle.close()
+        self._tprFileHandle = None
+
     def __repr__(self):
         return "gmx.fileio.TprFile('{}', '{}')".format(self.filename, self.mode)
+
+    def __enter__(self):
+        # self._tprFileHandle = gmx.core.TprFile()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return
 
 class TrajectoryFile:
     """Provides an interface to Gromacs supported trajectory file formats.

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -15,7 +15,9 @@ class TprTestCase(unittest.TestCase):
         self.assertRaises(UsageError, TprFile, tpr_filename, 'x')
         # TprFile does not yet check whether file exists and is readable...
         #self.assertRaises(UsageError, TprFile, 1, 'r')
-        fh = TprFile(tpr_filename, 'r')
+        tprfile = TprFile(tpr_filename, 'r')
+        with tprfile as fh:
+            pass
 
     def test_tprcopy(self):
         _, temp_filename = tempfile.mkstemp(suffix='.tpr')

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -17,7 +17,11 @@ class TprTestCase(unittest.TestCase):
         #self.assertRaises(UsageError, TprFile, 1, 'r')
         tprfile = TprFile(tpr_filename, 'r')
         with tprfile as fh:
-            pass
+            cpp_object = fh._tprFileHandle
+            assert not cpp_object is None
+            params = cpp_object.params()
+            assert "nsteps" in params
+            assert not "foo" in params
 
     def test_tprcopy(self):
         _, temp_filename = tempfile.mkstemp(suffix='.tpr')


### PR DESCRIPTION
Fixes #192 

* Map GROMACS parameter input types to C++ types, generic gmxapi types, and Python types.
* Map MDP entries to t_inputrec entries (incomplete, but the framework is clear, now).
* Export a SimulationParameters class and a TprFileHandle class from which it can be extracted.