### PR TITLE
Rewrite TPR file with updated parameters

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ needs_sphinx = '1.4'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
     'sphinx.ext.doctest',
     'sphinx.ext.todo',
@@ -371,6 +372,9 @@ latex_elements = {
 # New in version 1.3.
 #
 # autodoc_mock_imports = []
+
+# See http://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autoclass_content
+autoclass_content = 'both'
 
 ## Napoleon settings
 #napoleon_google_docstring = True

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -62,7 +62,7 @@ Python Classes
 - :class:`gmx.workflow.WorkSpec`
 - :class:`gmx.workflow.WorkElement`
 - :class:`gmx.context.Context`
-- :class:`gmx.context.ParallelArrayContext`
+- :class:`gmx.fileio.TprFile`
 - :class:`gmx.status.Status`
 
 Python context managers

--- a/src/gmx/core/export_tprfile.cpp
+++ b/src/gmx/core/export_tprfile.cpp
@@ -3,36 +3,83 @@
 //
 
 #include "core.h"
+#include "mdparams.h"
 #include "tprfile.h"
 #include <pybind11/stl.h>
 
 namespace gmxpy {
 
+
 void detail::export_tprfile(pybind11::module &m)
 {
     namespace py = pybind11;
-    using gmxapicompat::TprFileHandle;
+    using gmxapicompat::GmxMdParams;
+    using gmxapicompat::TprReadHandle;
     using gmxapicompat::readTprFile;
 
-    py::class_<TprFileHandle> tprfile(m, "TprFile");
-    tprfile.def("params",
-            [](const TprFileHandle& self)
+    py::class_<GmxMdParams> mdparams(m, "SimulationParameters");
+    // We don't want Python users to create invalid params objects, so don't
+    // export a constructor until we can default initialize a valid one.
+    //    mdparams.def(py::init());
+    mdparams.def("extract",
+            [](const GmxMdParams& self)
             {
                 py::dict dictionary;
-                auto params = gmxapicompat::getMdParams(self);
-                for (const auto& key : gmxapicompat::keys(params))
+                for (const auto& key : gmxapicompat::keys(self))
                 {
                     const auto& paramType = gmxapicompat::mdParamToType(key);
                     if (gmxapicompat::isFloat(paramType))
                     {
-                        dictionary[key.c_str()] = extractParam(params, key, double());
+                        dictionary[key.c_str()] = extractParam(self, key, double());
                     }
                     else if (gmxapicompat::isInt(paramType))
                     {
-                        dictionary[key.c_str()] = extractParam(params, key, int64_t());
+                        dictionary[key.c_str()] = extractParam(self, key, int64_t());
                     }
                 }
                 return dictionary;
+            },
+            "Get a dictionary of the parameters.");
+
+//    mdparams.def("set",
+//                 [](GmxMdParams* self, py::dict input)
+//                 {},
+//                 "Set several parameters at once."
+//                 );
+
+    // Overload a setter for each known type and None
+    mdparams.def("set",
+                 [](GmxMdParams* self, const std::string& key, py::int_ value)
+                 {
+                     gmxapicompat::setParam(self, key, py::cast<int64_t>(value));
+                 },
+                 py::arg("key").none(false),
+                 py::arg("value").none(false),
+                 "Use a dictionary to update simulation parameters.");
+    mdparams.def("set",
+                 [](GmxMdParams* self, const std::string& key, py::float_ value)
+                 {
+                     gmxapicompat::setParam(self, key, py::cast<double>(value));
+                 },
+                 py::arg("key").none(false),
+                 py::arg("value").none(false),
+                 "Use a dictionary to update simulation parameters.");
+    mdparams.def("set",
+                 [](GmxMdParams* self, const std::string& key, py::none)
+                 {
+                     // unsetParam(self, key);
+                 },
+                 py::arg("key").none(false),
+                 py::arg("value"),
+                 "Use a dictionary to update simulation parameters.");
+
+
+    py::class_<TprReadHandle> tprfile(m, "TprFile");
+    tprfile.def("params",
+            [](const TprReadHandle& self)
+            {
+                auto params = gmxapicompat::getMdParams(self);
+                return params;
             });
 
     m.def("read_tprfile",
@@ -40,8 +87,35 @@ void detail::export_tprfile(pybind11::module &m)
             py::arg("filename"),
             "Get a handle to a TPR file resource for a given file name.");
 
+    m.def("write_tprfile",
+            [](std::string filename, const GmxMdParams& parameterObject)
+            {
+                auto tprReadHandle = gmxapicompat::getSourceFileHandle(parameterObject);
+                auto params = gmxapicompat::getMdParams(tprReadHandle);
+                auto structure = gmxapicompat::getStructureSource(tprReadHandle);
+                auto state = gmxapicompat::getSimulationState(tprReadHandle);
+                auto topology = gmxapicompat::getTopologySource(tprReadHandle);
+                gmxapicompat::writeTprFile(filename, params, structure, state, topology);
+            },
+            py::arg("filename").none(false),
+            py::arg("parameters"),
+            "Write a new TPR file with the provided data.");
+
     m.def("copy_tprfile",
-          &gmxpy::copy_tprfile,
+          [](const gmxapicompat::TprReadHandle& input, std::string outfile)
+          {
+              return gmxpy::copy_tprfile(input, outfile);
+          },
+          py::arg("source"),
+          py::arg("destination"),
+          "Copy a TPR file from `source` to `destination`."
+          );
+
+    m.def("copy_tprfile",
+          [](std::string input, std::string output, double end_time)
+          {
+              return gmxpy::copy_tprfile(input, output, end_time);
+          },
           py::arg("source"),
           py::arg("destination"),
           py::arg("end_time"),

--- a/src/gmx/core/mdparams.h
+++ b/src/gmx/core/mdparams.h
@@ -126,6 +126,8 @@ double extractParam(const gmxapicompat::GmxMdParams& params, const std::string& 
 
 void setParam(gmxapicompat::GmxMdParams* params, const std::string& name, double value);
 void setParam(gmxapicompat::GmxMdParams* params, const std::string& name, int64_t value);
+// TODO: unsetParam
+
 
 // Anonymous namespace to confine helper function definitions to file scope.
 namespace

--- a/src/gmx/fileio.py
+++ b/src/gmx/fileio.py
@@ -210,7 +210,8 @@ def write_tpr_file(output, input=None):
         make it an implementation detail of a wrapper object that has standard
         interfaces for the non-implementation-dependent encapsulated data.
 
-    :return: TBD
+    Returns:
+        TBD : possibly a completion condition of some sort and/or handle to the new File
     """
 
     if not hasattr(input, 'parameters'):
@@ -229,6 +230,7 @@ def write_tpr_file(output, input=None):
     gmx.core.write_tprfile(output, parameters)
 
 
+# Note: this has been dead since at least 0.0.3, but we should revive it...
 class TrajectoryFile:
     """Provides an interface to Gromacs supported trajectory file formats.
 

--- a/src/gmx/fileio.py
+++ b/src/gmx/fileio.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals
 
 import os
 
-__all__ = ['TprFile', 'read_tpr']
+__all__ = ['TprFile', 'read_tpr', 'write_tpr_file']
 
 import gmx.core
 import gmx.util
@@ -67,12 +67,11 @@ class TprFile:
 class _NodeOutput(object):
     """Implement the `output` attribute of a simulation input node.
 
-        Attributes:
-            parameters: Simulation parameters for (re)written TPR file.
-            structure: Atomic details (not yet implemented)
-            topology: Molecular force field details (not yet implemented)
-            state: Simulation state information (not yet implemented)
-
+    Attributes:
+        parameters: Simulation parameters for (re)written TPR file.
+        structure: Atomic details (not yet implemented)
+        topology: Molecular force field details (not yet implemented)
+        state: Simulation state information (not yet implemented)
 
     """
     def __init__(self, parameters=None, structure=None, topology=None, state=None):
@@ -103,7 +102,10 @@ class _SimulationInput(object):
     Simulation input interface for a TPR file read by gmx.fileio.read_tpr()
 
     Attributes:
-        output : provides the `parameters` output port
+        parameters: Simulation parameters for (re)written TPR file.
+        structure: Atomic details (not yet implemented)
+        topology: Molecular force field details (not yet implemented)
+        state: Simulation state information (not yet implemented)
 
     """
     def __init__(self, tprfile):
@@ -111,27 +113,44 @@ class _SimulationInput(object):
             # This class is an implementation detail of TPR file I/O...
             raise gmx.exceptions.ApiError("Must be initialized from a gmx.fileio.TprFile object.")
         self.__tprfile = tprfile
+        self.__parameters = None
 
     @property
-    def output(self):
-        """Access the output ports of SimulationInput."""
-        return _NodeOutput(parameters=self.__tprfile)
+    def parameters(self):
+        if self.__parameters is None:
+            with self.__tprfile as fh:
+                self.__parameters = fh._tprFileHandle.params()
+        return self.__parameters
+
+    @property
+    def structure(self):
+        raise gmx.exceptions.FeatureNotAvailableError("property not implemented.")
+
+    @property
+    def topology(self):
+        raise gmx.exceptions.FeatureNotAvailableError("property not implemented.")
+
+    @property
+    def state(self):
+        raise gmx.exceptions.FeatureNotAvailableError("property not implemented.")
 
 
 def read_tpr(tprfile=None):
     """
     Get a simulation input object from a TPR run input file.
 
-    :param tprfile: TPR input object or filename
-    :return: simulation input object
+    Arguments:
+        tprfile : TPR input object or filename
+
+    Returns:
+         simulation input object
 
     The returned object may be inspected by the user. Simulation input parameters
-    may be extracted from the object's `output` through the nested attribute
-    `output.parameters`.
+    may be extracted through the `parameters` attribute.
 
     Example:
         >>> sim_input = gmx.fileio.read_tpr(tprfile=tprfilename)
-        >>> params = sim_input.output.parameters.extract()
+        >>> params = sim_input.parameters.extract()
         >>> print(params['init-step'])
         0
 
@@ -149,7 +168,7 @@ def read_tpr(tprfile=None):
 
 # In initial implementation, we extract the entire TPR file contents through the
 # TPR-backed GmxMdParams implementation.
-def writeTprFile(output, input=None):
+def write_tpr_file(output, input=None):
     """
     Create a new TPR file, combining user-provided input.
 
@@ -162,28 +181,34 @@ def writeTprFile(output, input=None):
     with output ports for `parameters`, `structure`, `topology`, and `state`, such
     as a TprFileHandle
 
-    Arguments
-        output: TPR file name to write.
-        input: simulation input data from which to write a simulation run input file.
+    Arguments:
+        output : TPR file name to write.
+        input : simulation input data from which to write a simulation run input file.
 
     Use this function to write a new TPR file with data updated from an
     existing TPR file. Keyword arguments are objects that can provide gmxapi
     compatible access to the necessary simulation input data.
 
     In the initial version, data must originate from an existing TPR file, and
-    only simulation parameters may be rewritten. See
+    only simulation parameters may be rewritten. See gmx.fileio.read_tpr()
+
+    Example:
+        >>> sim_input = gmx.fileio.read_tpr(tprfile=tprfilename)
+        >>> sim_input.parameters.set('init-step', 1)
+        >>> gmx.fileio.write_tpr_file(newfilename, input=sim_input)
 
     Warning:
         The interface is in flux.
 
-    \todo Be consistent about terminology for "simulation state".
-    We are currently using "simulation state" to refer both to the aggregate of
-    data (superset) necessary to launch or continue a simulation _and_ to the
-    extra data (subset) necessary to capture full program state, beyond the
-    model/method input parameters and current phase space coordinates. Maybe we
-    shouldn't expose that as a separate user-accessible object and should instead
-    make it an implementation detail of a wrapper object that has standard
-    interfaces for the non-implementation-dependent encapsulated data.
+    TODO:
+        Be consistent about terminology for "simulation state".
+        We are currently using "simulation state" to refer both to the aggregate of
+        data (superset) necessary to launch or continue a simulation _and_ to the
+        extra data (subset) necessary to capture full program state, beyond the
+        model/method input parameters and current phase space coordinates. Maybe we
+        shouldn't expose that as a separate user-accessible object and should instead
+        make it an implementation detail of a wrapper object that has standard
+        interfaces for the non-implementation-dependent encapsulated data.
 
     :return: TBD
     """
@@ -201,7 +226,7 @@ def writeTprFile(output, input=None):
 
     if not isinstance(parameters, gmx.core.SimulationParameters):
         raise gmx.exceptions.TypeError("You must provide a gmx.core.SimulationParameters object to `parameters` as input.")
-    gmx.core.writeTpr(output, parameters)
+    gmx.core.write_tprfile(output, parameters)
 
 
 class TrajectoryFile:

--- a/src/gmx/fileio.py
+++ b/src/gmx/fileio.py
@@ -147,6 +147,20 @@ def read_tpr(tprfile=None):
 
     return _SimulationInput(tprfile)
 
+# In initial implementation, we extract the entire TPR file contents through the
+# TPR-backed GmxMdParams implementation.
+def writeTprFile(output, params=None, structure=None, topology=None, state=None):
+    if topology is not None:
+        raise gmx.exceptions.FeatureNotAvailableError("Can't rewrite topology yet.")
+    if structure is not None:
+        raise gmx.exceptions.FeatureNotAvailableError("Can't rewrite structure yet.")
+    if state is not None:
+        raise gmx.exceptions.FeatureNotAvailableError("Can't rewrite state yet.")
+    if not isinstance(params, gmx.core.SimulationParameters):
+        raise gmx.exceptions.TypeError("You must provide a gmx.core.SimulationParameters object to `params` as input.")
+    gmx.core.writeTpr(output,  params)
+
+
 class TrajectoryFile:
     """Provides an interface to Gromacs supported trajectory file formats.
 

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -20,7 +20,7 @@ class TprTestCase(unittest.TestCase):
         with tprfile as fh:
             cpp_object = fh._tprFileHandle
             assert not cpp_object is None
-            params = cpp_object.params()
+            params = cpp_object.params().extract()
             assert "nsteps" in params
             assert not "foo" in params
 

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -30,7 +30,7 @@ class TprTestCase(unittest.TestCase):
         Transitively test gmx.fileio.read_tpr()
         """
         sim_input = read_tpr(tpr_filename)
-        params = sim_input.output.parameters
+        params = sim_input.output.parameters.extract()
         dt = params['dt']
         nsteps = params['nsteps']
         init_step = params['init-step']
@@ -41,7 +41,7 @@ class TprTestCase(unittest.TestCase):
         assert gmx.core.copy_tprfile(source=tpr_filename, destination=temp_filename, end_time=new_endtime)
         tprfile = TprFile(temp_filename, 'r')
         with tprfile as fh:
-            params = read_tpr(fh).output.parameters
+            params = read_tpr(fh).output.parameters.extract()
             dt = params['dt']
             nsteps = params['nsteps']
             init_step = params['init-step']

--- a/src/gmx/test/test_fileio.py
+++ b/src/gmx/test/test_fileio.py
@@ -24,24 +24,27 @@ class TprTestCase(unittest.TestCase):
             assert "nsteps" in params
             assert not "foo" in params
 
-    def test_tprcopy(self):
+    def test_core_tprcopy_alt(self):
         """Test gmx.core.copy_tprfile() for update of end_time.
+
+        Set a new end time that is 5000 steps later than the original. Read dt
+        from file to avoid floating point round-off errors.
 
         Transitively test gmx.fileio.read_tpr()
         """
+        additional_steps = 5000
         sim_input = read_tpr(tpr_filename)
-        params = sim_input.output.parameters.extract()
+        params = sim_input.parameters.extract()
         dt = params['dt']
         nsteps = params['nsteps']
         init_step = params['init-step']
         initial_endtime = (init_step + nsteps) * dt
-        new_endtime = initial_endtime + 5000*dt
+        new_endtime = initial_endtime + additional_steps*dt
         _, temp_filename = tempfile.mkstemp(suffix='.tpr')
-        # When we have some more inspection tools we can do more than just check for success.
-        assert gmx.core.copy_tprfile(source=tpr_filename, destination=temp_filename, end_time=new_endtime)
+        gmx.core.copy_tprfile(source=tpr_filename, destination=temp_filename, end_time=new_endtime)
         tprfile = TprFile(temp_filename, 'r')
         with tprfile as fh:
-            params = read_tpr(fh).output.parameters.extract()
+            params = read_tpr(fh).parameters.extract()
             dt = params['dt']
             nsteps = params['nsteps']
             init_step = params['init-step']
@@ -49,6 +52,28 @@ class TprTestCase(unittest.TestCase):
 
         os.unlink(temp_filename)
 
+    def test_write_tpr_file(self):
+        """Test gmx.fileio.write_tpr_file() using gmx.core API.
+        """
+        additional_steps = 5000
+        sim_input = read_tpr(tpr_filename)
+        params = sim_input.parameters.extract()
+        nsteps = params['nsteps']
+        init_step = params['init-step']
+        new_nsteps = init_step + additional_steps
+
+        sim_input.parameters.set('nsteps', new_nsteps)
+
+        _, temp_filename = tempfile.mkstemp(suffix='.tpr')
+        gmx.fileio.write_tpr_file(temp_filename, input=sim_input)
+        tprfile = TprFile(temp_filename, 'r')
+        with tprfile as fh:
+            params = read_tpr(fh).parameters.extract()
+            dt = params['dt']
+            assert params['nsteps'] != nsteps
+            assert params['nsteps'] == new_nsteps
+
+        os.unlink(temp_filename)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Fixes #86 

Use TPR-backed SimulationParameters to allow writing a copy of a TPR file with updated parameters.
