### PR TITLE
Issue deprecation warning for DefaultContext.

### DIFF
--- a/src/gmx/context.py
+++ b/src/gmx/context.py
@@ -560,6 +560,7 @@ class DefaultContext(_libgromacsContext):
     """
     def __init__(self, work):
         # There is very little context abstraction at this point...
+        warnings.warn("Behavior of DefaultContext is unspecified starting in gmxapi 0.0.8.", DeprecationWarning)
         super(DefaultContext, self).__init__(work)
 
 class Context(object):


### PR DESCRIPTION
Minor tidying in advance of other works in progress.

gmx.context.DefaultContext will have to go away very soon. I want to
raise as many alarm bells as possible and not worry about breaking it.
Note, already officially deprecated (use get_context).