### PR TITLE
Update installation instructions w.r.t. GROMACS 2019.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -56,9 +56,11 @@ Requirements
 * This Python package
 * MD restraint plugins and sample gmxapi client code
 
-First, install `GROMACS 2019 <http://www.gromacs.org>`_ (beta 2 or more recent)
+First, install `GROMACS 2019 <http://www.gromacs.org>`_
 or the Kasson Lab GROMACS fork available from
-`github.com/kassonlab/gromacs-gmxapi <https://github.com/kassonlab/gromacs-gmxapi/>`_
+`github.com/kassonlab/gromacs-gmxapi <https://github.com/kassonlab/gromacs-gmxapi/>`_.
+Build from source and set ``GMXAPI=ON`` with ``ccmake`` or using the ``-DGMXAPI=ON``
+``cmake`` command line configuration flag.
 
 Then, install this Python package as documented below. E.g.
 `github.com/kassonlab/gmxapi <https://github.com/kassonlab/gmxapi/>`_.
@@ -76,10 +78,12 @@ of CMake.
 Full gmxapi functionality may also require an MPI compiler (e.g. ``mpicc``).
 
 The Python package requires a GROMACS installation.
-Build and install `GROMACS 2019 <http://www.gromacs.org>`_ (beta 2 or more recent)
+Build and install `GROMACS 2019 <http://www.gromacs.org>`_
 or the Kasson Lab GROMACS fork (available from
 `github.com/kassonlab/gromacs-gmxapi <https://github.com/kassonlab/gromacs-gmxapi/>`_)
 before proceeding.
+Be sure to set ``GMXAPI=ON`` with ``ccmake`` or using the ``-DGMXAPI=ON``
+``cmake`` command line configuration flag.
 Then, "source" the GMXRC file from the GROMACS installation as you normally would
 before using GROMACS, or note its installation location so that you can pass it
 to the build configuration.
@@ -240,9 +244,10 @@ home directory.
     mkdir build
     cd build
     cmake ../gromacs -DGMX_THREAD_MPI=ON \
-                     -DCMAKE_CXX_COMPILER=`which g++`
-                     -DCMAKE_C_COMPILER=`which gcc`
-                     -DCMAKE_INSTALL_PREFIX=$HOME/gromacs-gmxapi
+                     -DCMAKE_CXX_COMPILER=`which g++` \
+                     -DCMAKE_C_COMPILER=`which gcc` \
+                     -DCMAKE_INSTALL_PREFIX=$HOME/gromacs-gmxapi \
+                     -DGMXAPI=ON
     make -j8 && make install
 
 .. note::

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  system_packages: true
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
Final release of GROMACS 2019 requires manually setting GMXAPI=ON.
Also readthedocs configuration is updated with the addition of a readthedocs.yml file.

Fixes #218