### PR TITLE
Tie gmxapi 0.0.7 to GROMACS 2019

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,6 @@ install:
   - ccache -s
   - ./ci_scripts/install_cmake.sh
   - ./ci_scripts/install_gromacs_2019.sh
-  - if [ "${TRAVIS_BRANCH}" != "master" ] ; then ./ci_scripts/install_gromacs_devel.sh ; fi
 
 before_script:
   - export CCACHE_DIR=$HOME/.ccache_gmxapi
@@ -67,22 +66,3 @@ script:
   - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/test_installers.sh
   - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/pygmx.sh
   - ./ci_scripts/sample_restraint.sh release-0_0_7
-# The following scripting structure looks funny, but exists to control the
-# failure exit points and Travis-CI output.
-#  - |
-#    if [ "${TRAVIS_BRANCH}" != master ] ; then
-#      source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/test_installers.sh
-#    fi
-#  - |
-#    if [ "${TRAVIS_BRANCH}" != master ] ; then
-#      source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/pygmx.sh
-#    fi
-#  - |
-#    if [ "${TRAVIS_BRANCH}" != master ] ; then
-#      ./ci_scripts/sample_restraint.sh devel
-#    fi
-
-# At some point, we should test more types of interactions between components, such as both static and dynamically
-# linked builds, and components built with different compilers.
-#
-# Reference https://docs.travis-ci.com/user/customizing-the-build/#The-Build-Lifecycle

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,7 @@ install:
   - export CCACHE_DIR=$HOME/.ccache_gmxapi
   - ccache -s
   - ./ci_scripts/install_cmake.sh
-# 0.0.8 Does not currently attempt to be compatible with GROMACS 2019.
-#  - ./ci_scripts/install_gromacs_2019.sh
+  - ./ci_scripts/install_gromacs_2019.sh
   - if [ "${TRAVIS_BRANCH}" != "master" ] ; then ./ci_scripts/install_gromacs_devel.sh ; fi
 
 before_script:
@@ -65,24 +64,23 @@ before_script:
   - eval $(./ci_scripts/prepare_python.sh)
 
 script:
-# 0.0.8 Does not currently attempt to be compatible with GROMACS 2019.
-#  - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/test_installers.sh
-#  - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/pygmx.sh
-#  - ./ci_scripts/sample_restraint.sh release-0_0_7
+  - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/test_installers.sh
+  - source $HOME/install/gromacs_2019/bin/GMXRC && ./ci_scripts/pygmx.sh
+  - ./ci_scripts/sample_restraint.sh release-0_0_7
 # The following scripting structure looks funny, but exists to control the
 # failure exit points and Travis-CI output.
-  - |
-    if [ "${TRAVIS_BRANCH}" != master ] ; then
-      source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/test_installers.sh
-    fi
-  - |
-    if [ "${TRAVIS_BRANCH}" != master ] ; then
-      source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/pygmx.sh
-    fi
-  - |
-    if [ "${TRAVIS_BRANCH}" != master ] ; then
-      ./ci_scripts/sample_restraint.sh devel
-    fi
+#  - |
+#    if [ "${TRAVIS_BRANCH}" != master ] ; then
+#      source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/test_installers.sh
+#    fi
+#  - |
+#    if [ "${TRAVIS_BRANCH}" != master ] ; then
+#      source $HOME/install/gromacs_devel/bin/GMXRC && ./ci_scripts/pygmx.sh
+#    fi
+#  - |
+#    if [ "${TRAVIS_BRANCH}" != master ] ; then
+#      ./ci_scripts/sample_restraint.sh devel
+#    fi
 
 # At some point, we should test more types of interactions between components, such as both static and dynamically
 # linked builds, and components built with different compilers.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "OS X deployment target below 10.9 does not use C++11 standard library" FORCE)
 
 # Sets the PROJECT_VERSION variable, as well...
-project(gmxpy VERSION 0.0.8)
+project(gmxpy VERSION 0.0.7)
 
 # Only interpret if() arguments as variables or keywords when unquoted.
 cmake_policy(SET CMP0054 NEW)
@@ -51,8 +51,10 @@ unset(PYTHONLIBS_FOUND)
 find_package(PythonInterp)
 if (PYTHONINTERP_FOUND)
     message(STATUS "Found Python interpreter: ${PYTHON_EXECUTABLE}")
-    find_package(PythonLibs ${PYTHON_VERSION_STRING} EXACT)
-    if (PYTHONLIBS_FOUND)
+    # pybind11 is included as a subtree and updated just with squash merges.
+    # Refer to https://www.atlassian.com/blog/git/alternatives-to-git-submodule-git-subtree
+    add_subdirectory(pybind11)
+    if (PYTHON_LIBRARIES)
         message(STATUS "Python headers in ${PYTHON_INCLUDE_DIRS}")
         message(STATUS "Python libraries in ${PYTHON_LIBRARIES}")
         if (GMXAPI_USER_INSTALL)
@@ -95,10 +97,6 @@ set(GMXAPI_INSTALL_PATH ${GMXAPI_DEFAULT_SITE_PACKAGES}/gmx CACHE PATH
     directory.")
 
 message(STATUS "Python module will be installed to GMXAPI_INSTALL_PATH cache value ${GMXAPI_INSTALL_PATH}")
-
-# pybind11 is included as a subtree and updated just with squash merges.
-# Refer to https://www.atlassian.com/blog/git/alternatives-to-git-submodule-git-subtree
-add_subdirectory(pybind11)
 
 add_subdirectory(src)
 

--- a/ci_scripts/install_gromacs_2019.sh
+++ b/ci_scripts/install_gromacs_2019.sh
@@ -15,10 +15,8 @@ else
 fi
 
 pushd $HOME
- [ -d gromacs-gmxapi ] || git clone --depth=1 --no-single-branch https://github.com/gromacs/gromacs.git gromacs
+ [ -d gromacs-gmxapi ] || git clone --depth=1 -b release-2019 --single-branch https://github.com/gromacs/gromacs.git gromacs
  pushd gromacs
-  git branch -a
-  git checkout release-2019
   pwd
   rm -rf build
   mkdir build

--- a/ci_scripts/install_gromacs_devel.sh
+++ b/ci_scripts/install_gromacs_devel.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Install the kassonlab GROMACS fork for experimental features.
 set -ev
 
 export GMX_DOUBLE=OFF
@@ -18,12 +19,9 @@ pushd $HOME
  [ -d gromacs-gmxapi ] || \
      git clone \
          --depth=1 \
-         --no-single-branch \
          https://github.com/kassonlab/gromacs-gmxapi.git \
          gromacs-kassonlab
  pushd gromacs-kassonlab
-  git branch -a
-  git checkout devel
   pwd
   rm -rf build
   mkdir build

--- a/ci_scripts/prepare_python.sh
+++ b/ci_scripts/prepare_python.sh
@@ -18,7 +18,8 @@ if [ -x "$PYTHON" ] ; then
     # Quiet output if QUIET is non-null
     echo "$PYTHON -m pip install --upgrade pip setuptools ${QUIET:+'-q'};
     $PYTHON -m pip install --no-cache-dir --upgrade --no-binary \":all:\" --force-reinstall mpi4py  ${QUIET:+'-q'};
-    $PYTHON -m pip install -r requirements.txt ${QUIET:+'-q'}"
+    $PYTHON -m pip install -r requirements.txt ${QUIET:+'-q'};
+    $PYTHON -m pip install -r docs/requirements.txt ${QUIET:+'-q'}"
 else
     echo "echo Set PYTHON to a Python interpreter before using prepare_python.sh"
 fi

--- a/ci_scripts/pygmx.sh
+++ b/ci_scripts/pygmx.sh
@@ -32,7 +32,7 @@ popd
 mpiexec -n 2 $PYTHON -m mpi4py -m pytest src/gmx/test
 
 # Check how well our compiler cache is working.
-`which ccache` && ccache -s
+ccache -s
 
 # Generate the list of Python packages present in the current environment.
 # Helpful, but not necessarily sufficient, for reproducibility.

--- a/ci_scripts/test_installers.sh
+++ b/ci_scripts/test_installers.sh
@@ -25,27 +25,9 @@ $PYTHON -m pip uninstall -y gmx
 rm -rf _skbuild dist gmx* build
 $PYTHON -m pip install .
 
-$PYTHON -m pytest src/gmx/test
-
 #
 # Test install with setup.py
 #
 $PYTHON -m pip uninstall -y gmx
 rm -rf _skbuild dist gmx* build
 $PYTHON setup.py install
-
-$PYTHON -m pytest src/gmx/test
-
-#
-# Test CMake-driven install
-#
-# Inactive. Duplicate of pygmx.sh
-#pip uninstall -y gmx
-#rm -rf _skbuild dist gmx* build
-#
-#rm -rf build
-#mkdir -p build
-#pushd build
-# cmake .. -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC -DPYTHON_EXECUTABLE=$PYTHON
-# make -j2
-#popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
-cmake>=0.8.0
+# Requirements to build the basic package and sphinx docs.
+cmake>=3.4.0
 pip>=10.1
 Pygments>=2.2.0
 setuptools>=28.0.0
-scikit-build>=0.7
 Sphinx>=1.6.3
 sphinx-rtd-theme>=0.2.4

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,24 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  image: stable
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: []
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.5
+  system_packages: true
+  install:
+    - requirements: docs/requirements.txt
+    - method: setuptools
+      path: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,9 @@
-cmake>=0.8.0
+cmake>=3.4.0
 networkx>=2.0
 pip>=10.1
-py>=1.4.34
 setuptools>=28.0.0
-scikit-build>=0.7
 # The following packages are not strictly necessary, but allow full documentation
 # builds and testing.
 mpi4py>=2
 numpy>=1
 pytest>=3.9
-Sphinx>=1.7
-sphinx-rtd-theme>=0.1

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,9 @@ from warnings import warn
 import setuptools
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
-from setuptools.command.test import test as TestCommand
 
 #import gmx.version
-__version__ = '0.0.8'
+__version__ = '0.0.7'
 
 extra_link_args=[]
 
@@ -45,9 +44,19 @@ if not build_gromacs:
         raise RuntimeError("Either set gmxapi_DIR or GROMACS_DIR to an existing installation\n"
                            "or set BUILDGROMACS to get a private copy. See installation docs...")
 
-def get_gromacs(url, cmake_args=(), build_args=()):
+def get_gromacs(url, cmake_args=(), build_args=(), install_dir=None):
     """Download, build, and install a local copy of gromacs to a temporary location.
     """
+    if os.path.exists(install_dir):
+        # Exit early if we've already got it.
+        cmake_config_dir = os.path.join(install_dir, 'share', 'cmake', 'gmxapi')
+        if not os.path.isdir(cmake_config_dir):
+            raise RuntimeError(
+                "No gmxapi cmake hints at {}. GROMACS built without gmxapi enabled?".format(
+                    cmake_config_dir))
+        return
+
+    cmake_args = list(cmake_args) + ['-DCMAKE_INSTALL_PREFIX=' + install_dir]
     try:
         import ssl
     except:
@@ -177,7 +186,7 @@ class CMakeGromacsBuild(build_ext):
                 # save some RAM
                 # We're pushing the limits of the readthedocs build host provisions. We might soon need
                 # a binary package or mock library for libgmxapi / libgromacs.
-                build_args += ['--', '-j2']
+                build_args += ['--', '-j4']
             else:
                 build_args += ['--', '-j8']
 
@@ -199,11 +208,10 @@ class CMakeGromacsBuild(build_ext):
         # Linking is a pain because the package is relocated to the site-packages directory. We should really do this
         # in two stages.
         if build_gromacs:
-            gromacs_url = "https://github.com/kassonlab/gromacs-gmxapi/archive/devel.zip"
+            gromacs_url = "https://github.com/gromacs/gromacs/archive/release-2019.zip"
             gmxapi_DIR = os.path.join(extdir, 'data/gromacs')
             if build_for_readthedocs:
-                extra_cmake_args = ['-DCMAKE_INSTALL_PREFIX=' + gmxapi_DIR,
-                                    '-DGMX_FFT_LIBRARY=fftpack',
+                extra_cmake_args = ['-DGMX_FFT_LIBRARY=fftpack',
                                     '-DGMX_GPU=OFF',
                                     '-DGMX_OPENMP=OFF',
                                     '-DGMX_SIMD=None',
@@ -212,8 +220,7 @@ class CMakeGromacsBuild(build_ext):
                                     '-DGMXAPI=ON',
                                     ]
             else:
-                extra_cmake_args = ['-DCMAKE_INSTALL_PREFIX=' + gmxapi_DIR,
-                                    '-DGMX_BUILD_OWN_FFTW=ON',
+                extra_cmake_args = ['-DGMX_BUILD_OWN_FFTW=ON',
                                     '-DGMX_GPU=OFF',
                                     '-DGMX_THREAD_MPI=ON',
                                     '-DGMXAPI=ON',
@@ -222,7 +229,7 @@ class CMakeGromacsBuild(build_ext):
             # Warning: make sure not to recursively build the Python module...
             get_gromacs(gromacs_url,
                         cmake_args + extra_cmake_args,
-                        build_args)
+                        build_args, gmxapi_DIR)
             GROMACS_DIR = gmxapi_DIR
         env['GROMACS_DIR'] = GROMACS_DIR
 
@@ -293,7 +300,7 @@ setup(
     # optional targets:
     #   docs requires 'docutils', 'sphinx>=1.4', 'sphinx_rtd_theme'
     #   build_gromacs requires 'cmake>=3.4'
-    install_requires=['setuptools>=28', 'scikit-build', 'cmake', 'networkx'],
+    install_requires=['setuptools>=28', 'cmake>=3.4', 'networkx>2'],
 
     author='M. Eric Irrgang',
     author_email='ericirrgang@gmail.com',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,7 +7,7 @@
 # cmake was invoked with `-DCMAKE_PREFIX_PATH=...` pointing to the GROMACS
 # installation directory. We can also check now for a GROMACS_DIR environment
 # variable and provide it with the HINTS option.
-find_package(gmxapi 0.0.8 REQUIRED
+find_package(gmxapi 0.0.7 REQUIRED
         HINTS "$ENV{GROMACS_DIR}"
         )
 if(gmxapi_FOUND)


### PR DESCRIPTION
Revert version bump from 0.0.8 to 0.0.7. After this change, the 'devel' branch can be merged to 'master' and closed. The release-0.0.7 branch will be the terminal release branch for the `git` tree that has included `master` in this repository thus far. Moving forward, `release-0.0.7` will be kept in synch with the GROMACS release-2019 branch and the `master` branch of this repository will undergo a one-time _replacement_ with (a fork of) the GROMACS master branch. Future gmxapi releases will be contained in the GROMACS repository (or forks thereof).

Refs #188
