### PR TITLE
Use latest tagged release of mpi4py in CI tests.

### DIFF
--- a/ci_scripts/prepare_python.sh
+++ b/ci_scripts/prepare_python.sh
@@ -8,12 +8,10 @@
 
 set -ev
 
-# TODO: Use a tagged release of mpi4py. 3.0.2 did not support Python 3.8.0.
-
 if [ -x "$PYTHON" ] ; then
     # Quiet output if QUIET is non-null
     $PYTHON -m pip install --upgrade pip setuptools ${QUIET:+'-q'}
-    $PYTHON -m pip install --no-cache-dir --upgrade --no-binary \":all:\" --force-reinstall https://bitbucket.org/mpi4py/mpi4py/get/maint.tar.gz  ${QUIET:+'-q'}
+    $PYTHON -m pip install --no-cache-dir --upgrade --no-binary \":all:\" --force-reinstall mpi4py ${QUIET:+'-q'}
     $PYTHON -m pip install -r python_packaging/src/requirements.txt ${QUIET:+'-q'}
     $PYTHON -m pip install -r python_packaging/requirements-docs.txt ${QUIET:+'-q'}
     $PYTHON -m pip install -r python_packaging/requirements-test.txt ${QUIET:+'-q'}


### PR DESCRIPTION
mpi4py 3.0.3 is now up on pypi and includes the updates for Python 3.8, so we can use the default version found by `pip` in the CI scripts.