### PR TITLE
gmxapi-252: make gmxapi 0.0.7 install docs less confusing.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -2,6 +2,16 @@
 Full installation instructions
 ==============================
 
+..  warning::
+
+    This documentation is for gmxapi 0.0.7 on GROMACS 2019.
+    Sources can be downloaded from https://github.com/kassonlab/gmxapi/releases
+    If cloning `the repository <https://github.com/kassonlab/gmxapi>`__ with git,
+    check out the ``release-0_0_7`` branch.
+
+    For gmxapi 0.1 or later and GROMACS 2020 or later, refer to
+    http://manual.gromacs.org/current/gmxapi/userguide/install.html
+
 .. highlight:: bash
 
 This document provides more thorough documentation about building and installing
@@ -317,6 +327,7 @@ system or you may need to load a module for it on an HPC system, which you will 
 
     git clone https://github.com/kassonlab/gmxapi.git
     cd gmxapi
+    git checkout release-0_0_7
 
 You will need to install some additional dependencies. The :file:`requirements.txt`
 file is provided for convenience. Also, note that ``pip`` must be

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -6,6 +6,13 @@ This document provides simple recipes for some specific installation scenarios.
 Refer to :doc:`install` for complete documentation about prerequisites and
 building from source code.
 
+..  warning::
+
+    This documentation is for gmxapi 0.0.7 on GROMACS 2019.
+    For gmxapi 0.1 or later and GROMACS 2020 or later, refer to
+    http://manual.gromacs.org/current/gmxapi/userguide/install.html
+
+
 .. contents:: Quick start recipes
     :local:
     :depth: 2
@@ -19,6 +26,7 @@ In the simplest case, the following should just work::
 
     git clone https://github.com/kassonlab/gmxapi.git
     cd gmxapi
+    git checkout release-0_0_7
     pip install -r requirements.txt
     pip install .
     cd


### PR DESCRIPTION
The `master` branch and `release-0_0_7` branches are laid out very
differently. Add clarification to the 0.0.7 installation instructions
to use the correct branch and instructions for

* gmxapi 0.0.7 / GROMACS 2019
* gmxapi 0.1+ / GROMACS 2020

Fixes #252