### PR TITLE
Further clarify versioning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 The gmxapi project provides interfaces for managing and extending molecular
 dynamics simulation workflows. In this repository, a Python package provides the 
-`gmx` module for high-level interaction with GROMACS via gmxapi 0.0.7.
+`gmx` module for high-level interaction with GROMACS 2019 via gmxapi 0.0.7.
 `gmx.core` provides Python bindings to the `gmxapi` C++ GROMACS external API.
 
 The gmxapi 0.0.7 Python project for GROMACS 2019 is hosted at
@@ -16,9 +16,7 @@ to a loosely-coupled ensemble of simulation trajectories.
 
 The whole thing is driven at the highest level by a simple Python interface.
 
-See the [version 0.0.7 documentation](https://gmxapi.readthedocs.io/en/release-0_0_7/)
-or the latest documentation at 
-[http://gmxapi.readthedocs.io/](http://gmxapi.readthedocs.io/en/latest/)
+See the [version 0.0.7 documentation](https://gmxapi.readthedocs.io/en/release-0_0_7/).
 
 Note that gmxapi is now (after 0.0.7) maintained as
 [part of](https://redmine.gromacs.org/projects/gromacs/repository/revisions/master/entry/python_packaging/README.md)
@@ -29,9 +27,10 @@ Irrgang, M. E., Hays, J. M., & Kasson, P. M.
 gmxapi: a high-level interface for advanced control and extension of molecular dynamics simulations.
 _Bioinformatics_ 2018.
 DOI: [10.1093/bioinformatics/bty484](https://doi.org/10.1093/bioinformatics/bty484)
-## Current master branch
-[![Build Status](https://travis-ci.org/kassonlab/gmxapi.svg?branch=master)](https://travis-ci.org/kassonlab/gmxapi)
-[![Documentation Status](https://readthedocs.org/projects/gmxapi/badge/?version=latest)](http://gmxapi.readthedocs.io/en/latest/?badge=latest)
+
+## 0.0.7 release branch
+[![Build Status](https://travis-ci.org/kassonlab/gmxapi.svg?branch=release-0_0_7)](https://travis-ci.org/kassonlab/gmxapi)
+[![Documentation Status](https://readthedocs.org/projects/gmxapi/badge/?version=release-0_0_7)](http://gmxapi.readthedocs.io/en/latest/?badge=latest)
 
 # Running simulations from Python
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,14 +2,16 @@
 gmxapi Python package
 =====================
 
-This project is hosted at https://www.github.com/kassonlab/gmxapi and is
-based on `GROMACS 2019 <http://manual.gromacs.org/documentation/>`_.
+gmxapi 0.0.7 is hosted at https://www.github.com/kassonlab/gmxapi and is
+based on `GROMACS 2019 <http://manual.gromacs.org/2019-current/index.html>`_.
 
-Refer to `ReadTheDocs <https://gmxapi.readthedocs.io/>`_ for documentation for
-each release.
-For the most up-to-date documentation, download the source code from
-`GitHub <https://www.github.com/kassonlab/gmxapi>`_ and
+Refer to `ReadTheDocs <https://gmxapi.readthedocs.io/en/release-0_0_7/>`_
+for documentation, or download the source code from
+`GitHub <https://github.com/kassonlab/gmxapi/tree/release-0_0_7>`_ and
 :ref:`build the docs <build_docs>` locally.
+
+For GROMACS 2020+ and gmxapi 0.1 or higher, refer to the GROMACS project
+`documentation <http://manual.gromacs.org/current/gmxapi/index.html>`__.
 
 ..  toctree::
     :maxdepth: 2


### PR DESCRIPTION
Update README and docs landing page to further clarify that gmxapi 0.0.7 is packaged separately from its dependency, GROMACS 2019, and that gmxapi 0.1 is packaged and documented with GROMACS 2020