### PR TITLE
Patch to work around CMake bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "OS X deployment target below 10.9 does not use C++11 standard library" FORCE)
 
 # Sets the PROJECT_VERSION variable, as well...
-project(gmxpy VERSION 0.0.7.post1)
+project(gmxpy VERSION 0.0.7.1)
 
 # Only interpret if() arguments as variables or keywords when unquoted.
 cmake_policy(SET CMP0054 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "OS X deployment target below 10.9 does not use C++11 standard library" FORCE)
 
 # Sets the PROJECT_VERSION variable, as well...
-project(gmxpy VERSION 0.0.7)
+project(gmxpy VERSION 0.0.7.post1)
 
 # Only interpret if() arguments as variables or keywords when unquoted.
 cmake_policy(SET CMP0054 NEW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,11 @@
 # If the libgmxapi dependency is satisfied by allowing setuptools to build GROMACS, it should use GROMACS_DIR to hint
 # the location.
 #
+# Workaround for issue #4563 for GROMACS releases that won't be patched.
+find_package(GROMACS REQUIRED
+             NAMES gromacs gromacs_d
+             HINTS "$ENV{GROMACS_DIR}"
+             )
 # find_package should find gmxapiConfig.cmake if the path to `gmx` is in PATH,
 # if gmxapi_DIR is set to the GROMACS installation directory, or if
 # cmake was invoked with `-DCMAKE_PREFIX_PATH=...` pointing to the GROMACS


### PR DESCRIPTION
Note that the 0.0.7 series is still in use for projects rigidly adhering to the original BRER paper, but packages were not released through pypi. Distribution is only through *e.g.* `git clone --depth=1 -b release-0_0_7post1 https://github.com/kassonlab/gmxapi.git` and a cmake-driven install.

The patch is validated through https://github.com/kassonlab/run_brer/pull/64 in https://github.com/kassonlab/run_brer/pull/64/commits/c61c694bfd12b789cc8de5eb651c0f5c647bd75c